### PR TITLE
Coveralls fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -321,6 +321,10 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           parallel-finished: true
+      - name: Rerun coverage workaround
+        # from https://github.com/lemurheavy/coveralls-public/issues/1653#issuecomment-1251587119
+        run: |
+          curl --location --request GET 'https://coveralls.io/rerun_build?repo_token=${{ secrets.GITHUB_TOKEN }}&build_num=${{ github.run_id }}'
           
   event_file:
     name: Event File

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -324,7 +324,7 @@ jobs:
       - name: Rerun coverage workaround
         # from https://github.com/lemurheavy/coveralls-public/issues/1653#issuecomment-1251587119
         run: |
-          curl --location --request GET 'https://coveralls.io/rerun_build?repo_token=${{ secrets.GITHUB_TOKEN }}&build_num=${{ github.run_id }}'
+          curl --location --request GET 'https://coveralls.io/rerun_build?repo_token=${{ secrets.COVERALLS_REPO_TOKEN }}&build_num=${{ github.run_id }}'
           
   event_file:
     name: Event File


### PR DESCRIPTION
This adds a workaround for coveralls, which sometimes miscalculates the coverage in the context of parallel builds. It follows advise from [this issue](https://github.com/lemurheavy/coveralls-public/issues/1653#issuecomment-1251587119).