### PR TITLE
Test + fix to avoid warnings for implicit size_t conversions

### DIFF
--- a/src/XAD/Literals.hpp
+++ b/src/XAD/Literals.hpp
@@ -83,13 +83,25 @@ struct ADTypeBase : public Expression<Scalar, Derived>
         a_ += x;
         return derived();
     }
+    template <class I>
+    XAD_INLINE typename std::enable_if<std::is_integral<I>::value, Derived>::type& 
+    operator+=(I x) { return *this += Scalar(x); }
     XAD_INLINE Derived& operator-=(Scalar rhs)
     {
         a_ -= rhs;
         return derived();
     }
+    template <class I>
+    XAD_INLINE typename std::enable_if<std::is_integral<I>::value, Derived>::type& 
+    operator-=(I x) { return *this -= Scalar(x); }
     XAD_INLINE Derived& operator*=(Scalar x) { return derived() = (derived() * x); }
+    template <class I>
+    XAD_INLINE typename std::enable_if<std::is_integral<I>::value, Derived>::type& 
+    operator*=(I x) { return *this *= Scalar(x); }
     XAD_INLINE Derived& operator/=(Scalar x) { return derived() = (derived() / x); }
+    template <class I>
+    XAD_INLINE typename std::enable_if<std::is_integral<I>::value, Derived>::type& 
+    operator/=(I x) { return *this /= Scalar(x); }
     XAD_INLINE Derived& operator+=(const value_type& x) { return derived() = derived() + x; }
     XAD_INLINE Derived& operator-=(const value_type& x) { return derived() = derived() - x; }
     XAD_INLINE Derived& operator*=(const value_type& x) { return derived() = derived() * x; }

--- a/test/Expressions_test.cpp
+++ b/test/Expressions_test.cpp
@@ -1802,3 +1802,18 @@ TEST(Expressions, doesNotCaptureConstexprByRef)
     EXPECT_THAT(result, Gt(0.0));
 }
 
+TEST(Expressions, notWarningAboutSizetToDouble)
+{
+    // recent compilers with high warning levels warn about size_t conversion to double,
+    // if a function does the conversion implicitly. For plain doubles, the expressions
+    // below don't trigger the warning - so for XAD types, they should not do that either.
+    xad::AReal<double> x = 2.0;
+    std::size_t d = 2;
+
+    x /= d;
+    x *= d;
+    x += d;
+    x -= d;
+
+    EXPECT_THAT(value(x), DoubleEq(2.0));
+}


### PR DESCRIPTION
# Description

This avoids warnings with higher warning levels when something like `operator/=` is called on an XAD literal with a `std::size_t` operand (or other integral types). With plain doubles, these warnings are not triggered either, so we don't want XAD to trigger them.

## Type of change

- Bug fix (non-breaking change which fixes an issue)
