### PR TITLE
Rework CI/CD with wider compiler support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,7 +121,7 @@ jobs:
       - name: setup
         run: |
           sudo apt-get update
-          sudo apt-get install -y ccache ninja-build gpg wget lcov ${{ matrix-compiler }}
+          sudo apt-get install -y ccache ninja-build gpg wget lcov ${{ matrix.compiler }}
       - name: Setup cmake
         uses: jwlawson/actions-setup-cmake@v1.13
       - name: ccache

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -192,7 +192,7 @@ jobs:
             reuse_slots: ON
     runs-on: ubuntu-latest
     container: 
-      image: conio/${{ matrix.compiler }}
+      image: conanio/${{ matrix.compiler }}
     steps:
       - uses: actions/checkout@v3
       - name: setup

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,75 +84,123 @@ jobs:
              -DCMAKE_PREFIX_PATH="${{ github.workspace }}/install"
           cmake --build .
   
-  build_and_test_linux:
+  build_and_test_clang:
     strategy:
       fail-fast: false
       matrix:
-        compiler: [gcc-4.8, gcc-7, gcc-9, gcc-11, clang-11, clang-14]
+        compiler: 
+          - clang-11
+          - clang-12
+          - clang-13
+          - clang-14
         config: [Release, Debug]
         reuse_slots: [OFF, ON]
         include:
           - compiler: clang-11
-            cxx: clang++
-            cc: clang
+            cxx: clang++-11
+            cc: clang-11
             os: ubuntu-20.04
-            install: false
+          - compiler: clang-12
+            cxx: clang++-12
+            cc: clang-12
+            os: ubuntu-22.04
+          - compiler: clang-13
+            cxx: clang++-13
+            cc: clang-13
+            os: ubuntu-22.04
           - compiler: clang-14
-            cxx: clang++
-            cc: clang
+            cxx: clang++-14
+            cc: clang-14
             os: ubuntu-22.04
-            install: false
-          - compiler: gcc-4.8
-            cxx: g++-4.8
-            cc: gcc-4.8
-            os: ubuntu-18.04
-            install: true
-          - compiler: gcc-7
-            cxx: g++
-            cc: gcc
-            os: ubuntu-18.04
-            install: false
-          - compiler: gcc-9
-            cxx: g++
-            cc: gcc
-            os: ubuntu-20.04
-            install: false
-          - compiler: gcc-11
-            cxx: g++
-            cc: gcc
-            os: ubuntu-22.04
-            install: false
+        exclude:
           - config: Debug
-            compiler: gcc-9
-            coverage: true
-            coverage_cxx_flags: "-fprofile-arcs -ftest-coverage" 
-            coverage_ld_flags: "-lgcov"
+            reuse_slots: ON
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: setup
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ccache ninja-build gpg wget lcov ${{ matrix-compiler }}
+      - name: Setup cmake
+        uses: jwlawson/actions-setup-cmake@v1.13
+      - name: ccache
+        uses: hendrikmuhs/ccache-action@v1.2.8
+        with:
+          key: linux-${{ matrix.compiler }}-${{ matrix.config }}-${{ matrix.reuse_slots }}
+      - name: configure
+        run: |
+          mkdir build
+          cd build
+          cmake .. -GNinja \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+            -DCMAKE_BUILD_TYPE=${{ matrix.config }} \
+            -DCMAKE_CXX_COMPILER=${{ matrix.cxx }} \
+            -DCMAKE_C_COMPILER=${{ matrix.cc }} \
+            -DCMAKE_INSTALL_PREFIX=${{ github.workspace }}/install
+      - name: build
+        run: |
+          cd build
+          cmake --build .
+      - name: test
+        run: |
+          cd build
+          ctest --no-compress-output --output-on-failure --parallel $(($(nproc) + 2)) --output-junit test_results.xml
+      - name: upload test results
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: Test Results (linux ${{ matrix.compiler }}-${{ matrix.config }}-${{ matrix.reuse_slots }})
+          path: build/test_results.xml
+      - name: install
+        run: |
+          cd build
+          cmake --install .
+      - name: install test
+        run: |
+          mkdir installtest
+          cd installtest
+          cmake ../samples -GNinja \
+            -DCMAKE_BUILD_TYPE=${{ matrix.config }} \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+            -DCMAKE_PREFIX_PATH="${{ github.workspace }}/install"  \
+            -DCMAKE_CXX_COMPILER=${{ matrix.cxx }} \
+            -DCMAKE_C_COMPILER=${{ matrix.cc }}
+          cmake --build .
+
+  build_and_test_gcc:
+    strategy:
+      fail-fast: false
+      matrix:
+        compiler: 
+          - gcc5
+          - gcc6 
+          - gcc7
+          - gcc8
+          - gcc9
+          - gcc10
+          - gcc11
+        config: [Release, Debug]
+        reuse_slots: [OFF, ON]
+        include:
           - config: Debug
-            compiler: gcc-11
             coverage: true
             coverage_cxx_flags: "-fprofile-arcs -ftest-coverage" 
             coverage_ld_flags: "-lgcov"
         exclude:
           - config: Debug
             reuse_slots: ON
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
+    container: 
+      image: conio/${{ matrix.compiler }}
     steps:
+      - uses: actions/checkout@v3
       - name: setup
         run: |
           sudo apt-get update
           sudo apt-get install -y ccache ninja-build gpg wget lcov
-      - name: compiler setup
-        if: ${{ matrix.install }}
-        run: |
-          sudo apt-get install -y ${{ matrix.cxx }} ${{ matrix.cc }}
-      - name: cmake setup
-        if: ${{ matrix.os == 'ubuntu-18.04' }}
-        run: |
-          wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | sudo tee /usr/share/keyrings/kitware-archive-keyring.gpg >/dev/null
-          echo 'deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ bionic main' | sudo tee /etc/apt/sources.list.d/kitware.list >/dev/null
-          sudo apt-get update
-          sudo apt-get install -y cmake
-      - uses: actions/checkout@v3
+      - name: Setup cmake
+        uses: jwlawson/actions-setup-cmake@v1.13
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1.2.8
         with:
@@ -182,7 +230,7 @@ jobs:
       - name: test
         run: |
           cd build
-          ctest --no-compress-output --output-on-failure -j3 --output-junit test_results.xml
+          ctest --no-compress-output --output-on-failure --parallel $(($(nproc) + 2)) --output-junit test_results.xml
       - name: upload test results
         if: always()
         uses: actions/upload-artifact@v3
@@ -235,8 +283,6 @@ jobs:
             coverage_ld_flags: "-ftest-coverage"
           - config: Release
             coverage: false
-            coverage_cxx_flags: "" 
-            coverage_ld_flags: ""
     steps:
       - name: setup
         run: |
@@ -313,7 +359,7 @@ jobs:
           cmake --build .
 
   coverage_finish:
-    needs: [ build_and_test_linux, build_and_test_macos]
+    needs: [ build_and_test_gcc, build_and_test_macos]
     runs-on: ubuntu-latest
     steps:
       - name: Coveralls Finished

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -196,10 +196,15 @@ jobs:
       options: --user root
     steps:
       - uses: actions/checkout@v3
-      - name: setup
+      - name: Setup tools
         run: |
           sudo apt-get update
-          sudo apt-get install -y ccache ninja-build gpg wget lcov
+          sudo apt-get install -y ccache ninja-build lcov
+      - name: GitHub WS Tmp
+        # there is an issue with workspace locations in github inside containers, which this works around
+        # see: https://github.com/actions/runner/issues/2058
+        run: |
+           echo "GITHUB_WORKSPACE=$GITHUB_WORKSPACE" >> $GITHUB_ENV
       - name: Setup cmake
         uses: jwlawson/actions-setup-cmake@v1.13
       - name: ccache
@@ -217,7 +222,7 @@ jobs:
             -DCMAKE_C_COMPILER=${{ matrix.cc }} \
             -DCMAKE_CXX_FLAGS="${{ matrix.coverage_cxx_flags }}" \
             -DCMAKE_EXE_LINKER_FLAGS="${{ matrix.coverage_ld_flags }}" \
-            -DCMAKE_INSTALL_PREFIX=${{ github.workspace }}/install
+            -DCMAKE_INSTALL_PREFIX=${{ env.GITHUB_WORKSPACE }}/install
       - name: build
         run: |
           cd build
@@ -227,7 +232,7 @@ jobs:
         run: |
           cd build
           mkdir coverage tmp
-          lcov --no-external --capture --initial --directory ${{ github.workspace }} --output-file ./tmp/lcov_base.info
+          lcov --no-external --capture --initial --directory ${{ env.GITHUB_WORKSPACE }} --output-file ./tmp/lcov_base.info
       - name: test
         run: |
           cd build
@@ -237,21 +242,21 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: Test Results (linux ${{ matrix.compiler }}-${{ matrix.config }}-${{ matrix.reuse_slots }})
-          path: build/test_results.xml
+          path: ${{ env.GITHUB_WORKSPACE }}/build/test_results.xml
       - name: coverage tests
         if: ${{ matrix.coverage }}
         run: |
           cd build
-          lcov --no-external --capture --directory ${{ github.workspace }} --output-file ./tmp/lcov_run.info
+          lcov --no-external --capture --directory ${{ env.GITHUB_WORKSPACE }} --output-file ./tmp/lcov_run.info
           lcov --add-tracefile ./tmp/lcov_base.info --add-tracefile ./tmp/lcov_run.info --output-file ./tmp/lcov_total.info
-          lcov --remove ./tmp/lcov_total.info "$PWD/*" "${{ github.workspace }}/test/*" "${{ github.workspace }}/samples/*" --output-file ./coverage/lcov.info
+          lcov --remove ./tmp/lcov_total.info "$PWD/*" "${{ env.GITHUB_WORKSPACE }}/test/*" "${{ env.GITHUB_WORKSPACE }}/samples/*" --output-file ./coverage/lcov.info
       - name: upload coverage results
         if: ${{ matrix.coverage }}
         uses: coverallsapp/github-action@master
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           flag-name: linux-${{ matrix.compiler }}-${{ matrix.reuse_slots }}
-          path-to-lcov: build/coverage/lcov.info
+          path-to-lcov: ${{env.GITHUB_WORKSPACE }}/build/coverage/lcov.info
           parallel: true
       - name: install
         run: |
@@ -265,7 +270,7 @@ jobs:
           cmake ../samples -GNinja \
             -DCMAKE_BUILD_TYPE=${{ matrix.config }} \
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
-            -DCMAKE_PREFIX_PATH="${{ github.workspace }}/install"  \
+            -DCMAKE_PREFIX_PATH="${{ env.GITHUB_WORKSPACE }}/install"  \
             -DCMAKE_CXX_COMPILER=${{ matrix.cxx }} \
             -DCMAKE_C_COMPILER=${{ matrix.cc }} \
             -DCMAKE_EXE_LINKER_FLAGS="${{ matrix.coverage_ld_flags }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,12 @@ jobs:
             compiler: msvc
             os: windows-2019
             vsvarsall: C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsall.bat
+          - config: Debug
+            sccache: false
+            cmake_extra: ""
+          - config: Release
+            sccache: true
+            cmake_extra: -DCMAKE_CXX_COMPILER_LAUNCHER=sccache
         exclude:
           - compiler: clang
             toolset: "14.1"
@@ -38,6 +44,7 @@ jobs:
         run: |
           choco install -y ninja sccache
       - name: ccache
+        if: ${{ matrix.sccache }}
         uses: hendrikmuhs/ccache-action@v1.2.9
         with:
           key: windows-${{ matrix.compiler }}-${{ matrix.toolset }}-${{ matrix.config }}
@@ -52,8 +59,8 @@ jobs:
              -DCMAKE_INSTALL_PREFIX="${{ github.workspace }}/install" ^
              -DCMAKE_CXX_COMPILER=${{ matrix.cxx }} ^
              -DCMAKE_C_COMPILER=${{ matrix.cc }} ^
-             -DCMAKE_BUILD_TYPE=${{ matrix.config }} ^
-             -DCMAKE_CXX_COMPILER_LAUNCHER=sccache
+             ${{ matrix.cmake_extra }} ^
+             -DCMAKE_BUILD_TYPE=${{ matrix.config }} 
       - name: build
         shell: cmd
         run: |
@@ -88,6 +95,7 @@ jobs:
              -DCMAKE_CXX_COMPILER=${{ matrix.cxx }} ^
              -DCMAKE_C_COMPILER=${{ matrix.cc }} ^
              -DCMAKE_BUILD_TYPE=${{ matrix.config }} ^
+             ${{ matrix.cmake_extra }} ^
              -DCMAKE_PREFIX_PATH="${{ github.workspace }}/install"
           cmake --build .
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -208,9 +208,9 @@ jobs:
             coverage: true
             coverage_cxx_flags: "-fprofile-arcs -ftest-coverage" 
             coverage_ld_flags: "-lgcov"
-          - config: Debug    # also with reusing slots, for coverage
+          - compiler: gcc11
+            config: Debug    # also with reusing slots, for coverage
             reuse_slots: ON
-            compiler: gcc11
             coverage: true
             coverage_cxx_flags: "-fprofile-arcs -ftest-coverage" 
             coverage_ld_flags: "-lgcov"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,7 @@ name: CI
 on: [push, pull_request]
 jobs:
   build_and_test_windows:
+    name: Windows
     strategy:
       fail-fast: false
       matrix:
@@ -32,10 +33,10 @@ jobs:
             toolset: "14.0"
     runs-on: ${{ matrix.os }}
     steps:
+      - uses: actions/checkout@v3
       - name: setup
         run: |
           choco install -y ninja sccache
-      - uses: actions/checkout@v3
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1.2.9
         with:
@@ -51,7 +52,8 @@ jobs:
              -DCMAKE_INSTALL_PREFIX="${{ github.workspace }}/install" ^
              -DCMAKE_CXX_COMPILER=${{ matrix.cxx }} ^
              -DCMAKE_C_COMPILER=${{ matrix.cc }} ^
-             -DCMAKE_BUILD_TYPE=${{ matrix.config }} 
+             -DCMAKE_BUILD_TYPE=${{ matrix.config }} ^
+             -DCMAKE_CXX_COMPILER_LAUNCHER=sccache
       - name: build
         shell: cmd
         run: |
@@ -90,6 +92,7 @@ jobs:
           cmake --build .
 
   build_and_test_clang:
+    name: Linux/Clang
     strategy:
       fail-fast: false
       matrix:
@@ -174,6 +177,7 @@ jobs:
           cmake --build .
 
   build_and_test_gcc:
+    name: Linux/Gcc
     strategy:
       fail-fast: false
       matrix:
@@ -285,6 +289,7 @@ jobs:
           cmake --build .
 
   build_and_test_macos:
+    name: Mac
     runs-on: macos-latest
     strategy:
       fail-fast: false
@@ -373,6 +378,7 @@ jobs:
           cmake --build .
 
   coverage_finish:
+    name: Coverage Collect
     needs: [ build_and_test_gcc, build_and_test_macos]
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,6 +199,8 @@ jobs:
       - uses: actions/checkout@v3
       - name: Setup tools
         run: |
+          cat /etc/lsb_release
+          /lib/x86_64-linux-gnu/libc.so.6
           sudo apt-get update
           sudo apt-get install -y ccache ninja-build lcov
       - name: GitHub WS Tmp

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,8 +34,13 @@ jobs:
     steps:
       - name: setup
         run: |
-          choco install -y ninja
+          choco install -y ninja sccache
       - uses: actions/checkout@v3
+      - name: ccache
+        uses: hendrikmuhs/ccache-action@v1.2.9
+        with:
+          key: windows-${{ matrix.compiler }}-${{ matrix.toolset }}-${{ matrix.config }}
+          variant: sccache
       - name: configure
         shell: cmd
         run: |
@@ -83,7 +88,7 @@ jobs:
              -DCMAKE_BUILD_TYPE=${{ matrix.config }} ^
              -DCMAKE_PREFIX_PATH="${{ github.workspace }}/install"
           cmake --build .
-  
+
   build_and_test_clang:
     strategy:
       fail-fast: false
@@ -121,11 +126,11 @@ jobs:
       - name: setup
         run: |
           sudo apt-get update
-          sudo apt-get install -y ccache ninja-build gpg wget lcov ${{ matrix.compiler }}
+          sudo apt-get install -y ccache ninja-build ${{ matrix.compiler }}
       - name: Setup cmake
         uses: jwlawson/actions-setup-cmake@v1.13
       - name: ccache
-        uses: hendrikmuhs/ccache-action@v1.2.8
+        uses: hendrikmuhs/ccache-action@v1.2.9
         with:
           key: linux-${{ matrix.compiler }}-${{ matrix.config }}-${{ matrix.reuse_slots }}
       - name: configure
@@ -199,7 +204,7 @@ jobs:
       - uses: actions/checkout@v3
       - name: Setup tools
         run: |
-          cat /etc/lsb_release
+          cat /etc/lsb-release
           /lib/x86_64-linux-gnu/libc.so.6
           sudo apt-get update
           sudo apt-get install -y ccache ninja-build lcov
@@ -211,7 +216,7 @@ jobs:
       - name: Setup cmake
         uses: jwlawson/actions-setup-cmake@v1.13
       - name: ccache
-        uses: hendrikmuhs/ccache-action@v1.2.8
+        uses: hendrikmuhs/ccache-action@v1.2.9
         with:
           key: linux-${{ matrix.compiler }}-${{ matrix.config }}-${{ matrix.reuse_slots }}
       - name: configure
@@ -303,7 +308,7 @@ jobs:
           brew install lcov
       - uses: actions/checkout@v3
       - name: ccache
-        uses: hendrikmuhs/ccache-action@v1.2.8
+        uses: hendrikmuhs/ccache-action@v1.2.9
         with:
           key: macos-${{ matrix.config }}
       - name: configure

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,15 +199,21 @@ jobs:
           - gcc11
         config: [Release, Debug]
         reuse_slots: [OFF, ON]
+        exclude:
+          - config: Debug
+            reuse_slots: ON
         include:
           - config: Debug
             compiler: gcc11
             coverage: true
             coverage_cxx_flags: "-fprofile-arcs -ftest-coverage" 
             coverage_ld_flags: "-lgcov"
-        exclude:
-          - config: Debug
+          - config: Debug    # also with reusing slots, for coverage
             reuse_slots: ON
+            compiler: gcc11
+            coverage: true
+            coverage_cxx_flags: "-fprofile-arcs -ftest-coverage" 
+            coverage_ld_flags: "-lgcov"
     runs-on: ubuntu-latest
     container: 
       image: conanio/${{ matrix.compiler }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -184,6 +184,7 @@ jobs:
         reuse_slots: [OFF, ON]
         include:
           - config: Debug
+            compiler: gcc11
             coverage: true
             coverage_cxx_flags: "-fprofile-arcs -ftest-coverage" 
             coverage_ld_flags: "-lgcov"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -193,6 +193,7 @@ jobs:
     runs-on: ubuntu-latest
     container: 
       image: conanio/${{ matrix.compiler }}
+      options: --user root
     steps:
       - uses: actions/checkout@v3
       - name: setup

--- a/README.md
+++ b/README.md
@@ -81,11 +81,11 @@ tests, and examples. You can try it out [here](https://github.com/xcelerit/qlxad
 ### Prerequisites
 
 -   [CMake][cmake], version 3.15 or newer
--   Linux: GCC 4.8 or newer, or Clang 11 or newer
+-   Linux: GCC 5.4 or newer, or Clang 11 or newer
 -   Windows:
     -   Visual Studio 2015 or newer
     -   Visual Studio with Clang toolset, 2019 or newer
--   MacOS: 10.9 or higher, with Apple Clang
+-   MacOS: 10.9 or higher, with Apple Clang 11 or newer
 -   Git client
 
 (See [tested platforms](#tested-platforms) for the list of platforms covered by continuous integration.)
@@ -331,20 +331,25 @@ Please also obey our [Code of Conduct](CODE_OF_CONDUCT.md) in all communication.
 The following platforms are part of the [continuous integration workflow][ci], i.e. they are tested on each commit. You can use other configurations at your own risk,
 or [submit a PR](CONTRIBUTING.md) to include it in the [CI workflow][ci].
 
-| Operating System     |  Compiler                         | Configurations                                    | Test Coverage Recorded |
-|----------------------|-----------------------------------|---------------------------------------------------|-------------------|
-| Windows Server 2019  | Visual Studio 2015 (Toolset 14.0) | Debug, Release                                    | no       |
-| Windows Server 2022  | Visual Studio 2017 (Toolset 14.1) | Debug, Release                                    | no       |
-| Windows Server 2022  | Visual Studio 2019 (Toolset 14.2) | Debug, Release                                    | no       |
-| Windows Server 2022  | Visual Studio 2022 (Toolset 14.3) | Debug, Release                                    | no       |
-| Windows Server 2022  | Clang 14.0         (Toolset 14.3) | Debug, Release                                    | no       |
-| Ubuntu 18.04         | GCC 4.8.5                         | Debug, Release, Release with XAD_TAPE_REUSE_SLOTS | no       |
-| Ubuntu 18.04         | GCC 7.5.0                         | Debug, Release, Release with XAD_TAPE_REUSE_SLOTS | no       |
-| Ubuntu 20.04         | GCC 9.4.0                         | Debug, Release, Release with XAD_TAPE_REUSE_SLOTS | yes      |
-| Ubuntu 20.04         | Clang 11.0.0                      | Debug, Release, Release with XAD_TAPE_REUSE_SLOTS | no       |
-| Ubuntu 22.04         | GCC 11.2.0                        | Debug, Release, Release with XAD_TAPE_REUSE_SLOTS | yes      |
-| Ubuntu 22.04         | Clang 14.0.0                      | Debug, Release, Release with XAD_TAPE_REUSE_SLOTS | no       |
-| MacOS 11.6.7         | AppleClang 13.0.0                 | Debug, Release                                    | yes      |
+| Operating System     |  Compiler                         | Configurations                                      | Test Coverage Recorded |
+|----------------------|-----------------------------------|-----------------------------------------------------|-------------------|
+| Windows Server 2019  | Visual Studio 2015 (Toolset 14.0) | Debug, Release                                      | no       |
+| Windows Server 2022  | Visual Studio 2017 (Toolset 14.1) | Debug, Release                                      | no       |
+| Windows Server 2022  | Visual Studio 2019 (Toolset 14.2) | Debug, Release                                      | no       |
+| Windows Server 2022  | Visual Studio 2022 (Toolset 14.3) | Debug, Release                                      | no       |
+| Windows Server 2022  | Clang 14.0         (Toolset 14.3) | Debug, Release                                      | no       |
+| Ubuntu 16.04         | GCC 5.4.0                         | Debug, Release, Release with `XAD_TAPE_REUSE_SLOTS` | no       |
+| Ubuntu 17.10         | GCC 6.4.0                         | Debug, Release, Release with `XAD_TAPE_REUSE_SLOTS` | no       |
+| Ubuntu 17.10         | GCC 7.2.0                         | Debug, Release, Release with `XAD_TAPE_REUSE_SLOTS` | no       |
+| Ubuntu 18.04         | GCC 8.4.0                         | Debug, Release, Release with `XAD_TAPE_REUSE_SLOTS` | no       |
+| Ubuntu 19.10         | GCC 9.2.0                         | Debug, Release, Release with `XAD_TAPE_REUSE_SLOTS` | no       |
+| Ubuntu 20.04         | GCC 10.3.0                        | Debug, Release, Release with `XAD_TAPE_REUSE_SLOTS` | no       |
+| Ubuntu 20.04         | GCC 11.1.0                        | Debug, Release, + both with `XAD_TAPE_REUSE_SLOTS`  | yes      |
+| Ubuntu 20.04         | Clang 11.0.0                      | Debug, Release, Release with `XAD_TAPE_REUSE_SLOTS` | no       |
+| Ubuntu 22.04         | Clang 12.0.1                      | Debug, Release, Release with `XAD_TAPE_REUSE_SLOTS` | no       |
+| Ubuntu 22.04         | Clang 13.0.1                      | Debug, Release, Release with `XAD_TAPE_REUSE_SLOTS` | no       |
+| Ubuntu 22.04         | Clang 14.0.0                      | Debug, Release, Release with `XAD_TAPE_REUSE_SLOTS` | no       |
+| MacOS 12.6.5         | AppleClang 14.0.0                 | Debug, Release                                      | yes      |
 
 
 ## Versioning

--- a/src/XAD/Complex.hpp
+++ b/src/XAD/Complex.hpp
@@ -2026,7 +2026,7 @@ XAD_INLINE std::complex<T> tanh_impl(const std::complex<T>& z)
     {
         if (xad::isinf(z.imag()) && z.imag() > 0.0)
         {
-#if defined(__APPLE__)
+#if defined(__APPLE__) || (defined(__GLIBC__) && __GLIBC__ == 2 && __GLIBC_MINOR__ < 27)
             return std::complex<T>(std::numeric_limits<nested>::quiet_NaN(),
                                    std::numeric_limits<nested>::quiet_NaN());
 #else
@@ -2035,7 +2035,7 @@ XAD_INLINE std::complex<T> tanh_impl(const std::complex<T>& z)
         }
         if (xad::isnan(z.imag()))
         {
-#if defined(__APPLE__)
+#if defined(__APPLE__) | (defined(__GLIBC__) && __GLIBC__ == 2 && __GLIBC_MINOR__ < 27)
             return std::complex<T>(std::numeric_limits<nested>::quiet_NaN(),
                                    std::numeric_limits<nested>::quiet_NaN());
 #else
@@ -2095,7 +2095,7 @@ XAD_INLINE std::complex<T> acosh_impl(const std::complex<T>& z)
     if (xad::isnan(z.imag()))
     {
         if (z.real() == 0.0)
-#if defined(__APPLE__)
+#if defined(__APPLE__) | (defined(__GLIBC__) && __GLIBC__ == 2 && __GLIBC_MINOR__ < 27)
             return std::complex<T>(std::numeric_limits<nested>::quiet_NaN(),
                                    std::numeric_limits<nested>::quiet_NaN());
 #else

--- a/src/XAD/Complex.hpp
+++ b/src/XAD/Complex.hpp
@@ -372,7 +372,7 @@ XAD_INLINE typename xad::ExprTraits<Derived>::value_type arg_impl(
 template <class T>
 XAD_INLINE T arg_impl(const std::complex<T>& z);
 
-#if (defined(_MSC_VER) && (_MSC_VER < 1920) || (defined(__GNUC__) && __GNUC__ < 5)) && !defined(__clang__)
+#if (defined(_MSC_VER) && (_MSC_VER < 1920) || (defined(__GNUC__) && __GNUC__ < 7)) && !defined(__clang__)
 template <class Scalar, class Derived>
 XAD_INLINE typename xad::ExprTraits<Derived>::value_type proj_impl(
     const xad::Expression<Scalar, Derived>& x);
@@ -1100,7 +1100,7 @@ XAD_INLINE complex<xad::FReal<T>> conj(const complex<xad::FReal<T>>& z)
     return ret;
 }
 
-#if ((defined(_MSC_VER) && (_MSC_VER < 1920)) || (defined(__GNUC__) && __GNUC__ < 5)) && !defined(__clang__)
+#if ((defined(_MSC_VER) && (_MSC_VER < 1920)) || (defined(__GNUC__) && __GNUC__ < 7)) && !defined(__clang__)
 template <class Scalar, class Derived>
 XAD_INLINE typename xad::ExprTraits<Derived>::value_type conj(
     const xad::Expression<Scalar, Derived>& x)
@@ -2284,7 +2284,7 @@ XAD_INLINE typename xad::ExprTraits<Derived>::value_type arg_impl(
 #endif
 }
 
-#if (defined(_MSC_VER) && (_MSC_VER < 1920) || (defined(__GNUC__) && __GNUC__ < 5)) && !defined(__clang__)
+#if (defined(_MSC_VER) && (_MSC_VER < 1920) || (defined(__GNUC__) && __GNUC__ < 7)) && !defined(__clang__)
 template <class Scalar, class Derived>
 XAD_INLINE typename xad::ExprTraits<Derived>::value_type proj_impl(
     const xad::Expression<Scalar, Derived>& x)

--- a/test/Complex_test.cpp
+++ b/test/Complex_test.cpp
@@ -2721,7 +2721,7 @@ TYPED_TEST(ComplexComplianceTest, TanhOfFiniteRealInfImag)
     EXPECT_THAT(xad::value(tanh(z2).imag()), IsNan());
 
     auto z3 = std::complex<TypeParam>(0.0, std::numeric_limits<double>::infinity());
-#if defined(__APPLE__)
+#if defined(__APPLE__) | (defined(__GLIBC__) && __GLIBC__ == 2 && __GLIBC_MINOR__ < 27)
     // on Mac, this return NaN (it shouldn't though)
     EXPECT_THAT(xad::value(tanh(z3).real()), IsNan());
 #else
@@ -2741,7 +2741,7 @@ TYPED_TEST(ComplexComplianceTest, TanhOfFiniteRealNanImag)
     EXPECT_THAT(xad::value(tanh(z2).imag()), IsNan());
 
     auto z3 = std::complex<TypeParam>(0.0, std::numeric_limits<double>::quiet_NaN());
-#if defined(__APPLE__)
+#if defined(__APPLE__) | (defined(__GLIBC__) && __GLIBC__ == 2 && __GLIBC_MINOR__ < 27)
     // Mac return Nan here
     EXPECT_THAT(xad::value(tanh(z3).real()), IsNan());
 #else
@@ -2959,7 +2959,7 @@ TYPED_TEST(ComplexComplianceTest, AcoshOfFiniteRealNanImag)
 
     auto z3 = std::complex<TypeParam>(0.0, std::numeric_limits<double>::quiet_NaN());
     EXPECT_THAT(xad::value(acosh(z3).real()), IsNan());
-#if defined(__APPLE__)
+#if defined(__APPLE__) | (defined(__GLIBC__) && __GLIBC__ == 2 && __GLIBC_MINOR__ < 27)
     EXPECT_THAT(xad::value(acosh(z3).imag()), IsNan());
 #else
     EXPECT_THAT(xad::value(acosh(z3).imag()), DoubleNear(M_PI / 2, 1e-9));

--- a/test/Complex_test.cpp
+++ b/test/Complex_test.cpp
@@ -1451,7 +1451,7 @@ TYPED_TEST(ComplexTest, ProjOfDoubleOrInteger)
     EXPECT_THAT(std::imag(std::proj(z)), DoubleNear(0.0, 1e-9));
     EXPECT_THAT(std::real(std::proj(z1)), IsPositiveInf());
     EXPECT_THAT(std::imag(std::proj(z1)), IsPositiveZero());
-#if ((defined(_MSC_VER) && _MSC_VER < 1920) || (defined(__GNUC__) && __GNUC__ < 5)) && !defined(__clang__)
+#if ((defined(_MSC_VER) && _MSC_VER < 1920) || (defined(__GNUC__) && __GNUC__ < 7)) && !defined(__clang__)
     // VS 2017 evaluates this differently
     EXPECT_THAT(std::real(std::proj(z1n)), IsNegativeInf());
 #else
@@ -1473,7 +1473,7 @@ TYPED_TEST(ComplexTest, ProjOfFloat)
     EXPECT_THAT(double(std::imag(std::proj(z))), DoubleNear(0.0, 1e-6));
     EXPECT_THAT(double(std::real(std::proj(z1))), IsPositiveInf());
     EXPECT_THAT(double(std::imag(std::proj(z1))), IsPositiveZero());
-#if ((defined(_MSC_VER) && _MSC_VER < 1920) || (defined(__GNUC__) && __GNUC__ < 5)) && !defined(__clang__)
+#if ((defined(_MSC_VER) && _MSC_VER < 1920) || (defined(__GNUC__) && __GNUC__ < 7)) && !defined(__clang__)
     // VS 2017 evaluates this differently
     EXPECT_THAT(double(std::real(std::proj(z1n))), IsNegativeInf());
 #else
@@ -1495,7 +1495,7 @@ TYPED_TEST(ComplexTest, ProjOfScalar)
     EXPECT_THAT(xad::value(std::imag(std::proj(z))), DoubleNear(0.0, 1e-9));
     EXPECT_THAT(xad::value(std::real(std::proj(z1))), IsPositiveInf());
     EXPECT_THAT(xad::value(std::imag(std::proj(z1))), IsPositiveZero());
-#if ((defined(_MSC_VER) && _MSC_VER < 1920) || (defined(__GNUC__) && __GNUC__ < 5)) && !defined(__clang__)
+#if ((defined(_MSC_VER) && _MSC_VER < 1920) || (defined(__GNUC__) && __GNUC__ < 7)) && !defined(__clang__)
     // VS 2017 evaluates this differently
     EXPECT_THAT(xad::value(std::real(std::proj(z1n))), IsNegativeInf());
 #else

--- a/test/ExpressionMath3_test.cpp
+++ b/test/ExpressionMath3_test.cpp
@@ -466,7 +466,7 @@ TEST(ExpressionsMath, maxMinForIntegersExplicit)
 #  pragma warning(disable : 4244)
 #elif defined(__GNUC__)
 #  pragma GCC diagnostic push
-#  if (__GNUC__ <= 5) && !defined(__clang__)
+#  if (__GNUC__ < 5) && !defined(__clang__)
 #    pragma GCC diagnostic ignored "-Wconversion"
 #  else
 #    pragma GCC diagnostic ignored "-Wfloat-conversion"

--- a/test/StdCompatibility_test.cpp
+++ b/test/StdCompatibility_test.cpp
@@ -262,7 +262,7 @@ TYPED_TEST(StdCompatibilityTempl, Traits)
 #if !(defined(__GNUC__) && __GNUC__ < 5) || defined(__clang__)
     static_assert(std::is_trivially_copyable<TypeParam>::value == fwd, "trivially copyable");
 #endif
-    static_assert(std::is_trivially_destructible<TypeParam>::value == fwd, "trially destructable for fwd mode");
+    static_assert(std::is_trivially_destructible<TypeParam>::value == fwd, "trivially destructable for fwd mode");
 }
 
 template <class T>


### PR DESCRIPTION
# Description

This fixes the currently-broken CI/CD workflows, since GitHub removed support for Ubuntu 18.04. It uses the Conan Docker images conveniently to add a wider range of compilers and platforms into the CI/CD system. Some minor compliance issues with NaN and Inf were fixed, so that XAD math functions match the native functions on all compilers.

Further, CCache is now used on all platforms, incl. Windows (sccache in that case). This speeds up the CI/CD build significantly. 

Note that workflows have been renamed.

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
