### PR TITLE
Add copysign math function + improve tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- More CI/CD workflows for all supported compiler versions
-- Improved tests and testing infrastructure
-- Added math function `copysign`
+-   More CI/CD workflows for all supported compiler versions
+-   Improved tests and testing infrastructure
+-   Added math function `copysign`
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- More CI/CD workflows for all supported compiler versions
+- Improved tests and testing infrastructure
+- Added math function `copysign`
+
 ### Changed
 
 ### Deprecated

--- a/doc/ref/math.rst
+++ b/doc/ref/math.rst
@@ -117,6 +117,12 @@ Absolute Values, Max, Min, and Rounding
    For derivatives, we therefore consider them both the same and calculate
    derivative accordingly.
 
+.. cpp:function:: T copysign(T x, T y)
+
+   Copies the sign of the floating point value ``y`` to the value ``x``, correctly
+   treating positive/negative zero, NaN, and Inf values. It uses :cpp::func:`signbit`
+   internally to determine the sign of ``y``.
+
 
 Trigonometric Functions
 -----------------------

--- a/src/XAD/StdCompatibility.hpp
+++ b/src/XAD/StdCompatibility.hpp
@@ -89,6 +89,7 @@ using xad::trunc;
 using xad::nextafter;
 using xad::ilogb;
 using xad::scalbn;
+using xad::copysign;
 
 template <class Scalar, class Derived>
 inline std::string to_string(const xad::Expression<Scalar, Derived>& _Val)

--- a/src/XAD/UnaryMathFunctors.hpp
+++ b/src/XAD/UnaryMathFunctors.hpp
@@ -421,11 +421,9 @@ rint
 lrint
 llrint
 nearbyint
-copysign
 nan
 nexttoward
 fdim
-isnormal
 
 isgreater
 isgreaterequal

--- a/src/XAD/UnaryOperators.hpp
+++ b/src/XAD/UnaryOperators.hpp
@@ -110,7 +110,8 @@ XAD_INLINE UnaryExpr<Scalar, ldexp_op<Scalar>, Expr> ldexp(const Expression<Scal
 template <class Scalar>
 XAD_INLINE UnaryExpr<Scalar, ldexp_op<Scalar>, ADVar<Scalar>> ldexp(const AReal<Scalar>& x, int y)
 {
-    return UnaryExpr<Scalar, ldexp_op<Scalar>, ADVar<Scalar>>(ADVar<Scalar>(x), ldexp_op<Scalar>(y));
+    return UnaryExpr<Scalar, ldexp_op<Scalar>, ADVar<Scalar>>(ADVar<Scalar>(x),
+                                                              ldexp_op<Scalar>(y));
 }
 
 // frexp
@@ -125,7 +126,8 @@ template <class Scalar>
 XAD_INLINE UnaryExpr<Scalar, frexp_op<Scalar>, ADVar<Scalar>> frexp(const AReal<Scalar>& x,
                                                                     int* exp)
 {
-    return UnaryExpr<Scalar, frexp_op<Scalar>, ADVar<Scalar>>(ADVar<Scalar>(x), frexp_op<Scalar>(exp));
+    return UnaryExpr<Scalar, frexp_op<Scalar>, ADVar<Scalar>>(ADVar<Scalar>(x),
+                                                              frexp_op<Scalar>(exp));
 }
 
 // modf - only enabled if iptr is nested type (double) or Scalar
@@ -140,7 +142,8 @@ template <class Scalar, class T>
 XAD_INLINE UnaryExpr<Scalar, modf_op<Scalar, T>, ADVar<Scalar>> modf(const AReal<Scalar>& x,
                                                                      T* iptr)
 {
-    return UnaryExpr<Scalar, modf_op<Scalar, T>, ADVar<Scalar>>(ADVar<Scalar>(x), modf_op<Scalar, T>(iptr));
+    return UnaryExpr<Scalar, modf_op<Scalar, T>, ADVar<Scalar>>(ADVar<Scalar>(x),
+                                                                modf_op<Scalar, T>(iptr));
 }
 
 // we put max/min here explicitly, as the 2 arguments to them must match
@@ -405,9 +408,8 @@ remquo(const AReal<Scalar>& a, typename ExprTraits<Scalar>::nested_type b, int* 
 // full specialisations as compilers otherwise pick up standard version
 // NOTE: They are only covering the most common cases
 
-XAD_INLINE UnaryExpr<double, scalar_remquo2_op<double, double>,
-                     ADVar<double>>
-remquo(const AReal<double>& a, double b, int* quo)
+XAD_INLINE UnaryExpr<double, scalar_remquo2_op<double, double>, ADVar<double>> remquo(
+    const AReal<double>& a, double b, int* quo)
 {
     return UnaryExpr<double, scalar_remquo2_op<double, double>, ADVar<double>>(
         ADVar<double>(a), scalar_remquo2_op<double, double>(b, quo));
@@ -420,9 +422,8 @@ XAD_INLINE UnaryExpr<double, scalar_remquo2_op<double, double>, FReal<double>> r
         a, scalar_remquo2_op<double, double>(b, quo));
 }
 
-XAD_INLINE UnaryExpr<double, scalar_remquo1_op<double, double>,
-                     ADVar<double>>
-remquo(double a, const AReal<double>& b, int* quo)
+XAD_INLINE UnaryExpr<double, scalar_remquo1_op<double, double>, ADVar<double>> remquo(
+    double a, const AReal<double>& b, int* quo)
 {
     return UnaryExpr<double, scalar_remquo1_op<double, double>, ADVar<double>>(
         ADVar<double>(b), scalar_remquo1_op<double, double>(a, quo));
@@ -444,12 +445,34 @@ XAD_INLINE int ilogb(const Expression<Scalar, Derived>& x)
 }
 
 template <class Scalar, class Derived>
-XAD_INLINE typename ExprTraits<Derived>::value_type scalbn(
-    const Expression<Scalar, Derived>& x, int exp)
+XAD_INLINE typename ExprTraits<Derived>::value_type scalbn(const Expression<Scalar, Derived>& x,
+                                                           int exp)
 {
     using std::scalbn;
     using T = typename ExprTraits<Derived>::value_type;
     return T(x * scalbn(1.0, exp));
+}
+
+template <class Scalar, class Derived, class T2>
+XAD_INLINE typename ExprTraits<Derived>::value_type copysign(const Expression<Scalar, Derived>& x,
+                                                             const T2& y)
+{
+    using T = typename ExprTraits<Derived>::value_type;
+    bool sign = signbit(y);
+    if (x < 0)
+    {
+        if (sign)
+            return T(x);
+        else
+            return T(-x);
+    }
+    else
+    {
+        if (sign)
+            return T(-x);
+        else
+            return T(x);
+    }
 }
 
 #undef XAD_UNARY_BINSCAL

--- a/test/ExpressionMath1_test.cpp
+++ b/test/ExpressionMath1_test.cpp
@@ -30,29 +30,29 @@
 LOCAL_TEST_FUNCTOR1(degreesAD, degrees(x))
 TEST(ExpressionsMath, degreesAD)
 {
-    mathTest_all(3.141592653589793238462643, 180.0, 57.2957795130823208767981548141051703324054725,
-                 0.0, degreesAD);
+    mathTest_all_aad(3.141592653589793238462643, 180.0,
+                     57.2957795130823208767981548141051703324054725, 0.0, degreesAD);
 }
 
 LOCAL_TEST_FUNCTOR1(degreesExpr, degrees(0.5 * x))
 TEST(ExpressionsMath, degreesExpr)
 {
-    mathTest_all(3.141592653589793238462643, 90.0,
-                 0.5 * 57.2957795130823208767981548141051703324054725, 0.0, degreesExpr);
+    mathTest_all_aad(3.141592653589793238462643, 90.0,
+                     0.5 * 57.2957795130823208767981548141051703324054725, 0.0, degreesExpr);
 }
 
 LOCAL_TEST_FUNCTOR1(radiansAD, radians(x));
 TEST(ExpressionsMath, radiansAD)
 {
-    mathTest_all(180.0, 3.141592653589793238462643, 0.0174532925199432957692369076848861271344287,
-                 0.0, radiansAD);
+    mathTest_all_aad(180.0, 3.141592653589793238462643,
+                     0.0174532925199432957692369076848861271344287, 0.0, radiansAD);
 }
 
 LOCAL_TEST_FUNCTOR1(radiansExpr, radians(2.0 * x))
 TEST(ExpressionsMath, radiansExpr)
 {
-    mathTest_all(180.0, 2.0 * 3.141592653589793238462643,
-                 2.0 * 0.0174532925199432957692369076848861271344287, 0.0, radiansExpr);
+    mathTest_all_aad(180.0, 2.0 * 3.141592653589793238462643,
+                     2.0 * 0.0174532925199432957692369076848861271344287, 0.0, radiansExpr);
 }
 
 LOCAL_TEST_FUNCTOR1(cosAD, cos(x))

--- a/test/ExpressionMath2_test.cpp
+++ b/test/ExpressionMath2_test.cpp
@@ -27,7 +27,6 @@
 #include <gtest/gtest.h>
 #include "TestHelpers.hpp"
 
-
 LOCAL_TEST_FUNCTOR1(powScalarBaseAD, pow(2.1, x))
 TEST(ExpressionsMath, powScalarBaseAD)
 {
@@ -116,12 +115,12 @@ TEST(ExpressionsMath, powExprExpr)
 }
 
 LOCAL_TEST_FUNCTOR1(pownAD, pown(x, 2))
-TEST(ExpressionsMath, pownAD) { mathTest_all(0.3, std::pow(0.3, 2), 2. * 0.3, 2., pownAD); }
+TEST(ExpressionsMath, pownAD) { mathTest_all_aad(0.3, std::pow(0.3, 2), 2. * 0.3, 2., pownAD); }
 
 LOCAL_TEST_FUNCTOR1(pownExpr, pown(2.3 * x, 2))
 TEST(ExpressionsMath, pownExpr)
 {
-    mathTest_all(0.3, std::pow(2.3 * 0.3, 2), 2.3 * 2 * 2.3 * 0.3, 2.3 * 2. * 2.3, pownExpr);
+    mathTest_all_aad(0.3, std::pow(2.3 * 0.3, 2), 2.3 * 2 * 2.3 * 0.3, 2.3 * 2. * 2.3, pownExpr);
 }
 
 LOCAL_TEST_FUNCTOR1(pown1AD, pow(x, 2))
@@ -187,51 +186,51 @@ LOCAL_TEST_FUNCTOR1(sabsAD, smooth_abs(x))
 TEST(ExpressionsMath, sabsAD)
 {
     double c = 0.001;
-    mathTest_all(0.3, std::abs(0.3), 1.0, 0.0, sabsAD);
-    mathTest_all(-0.3, std::abs(-0.3), -1.0, 0.0, sabsAD);
-    mathTest_all(0.0, std::abs(0.0), 0.0, 4. / c, sabsAD);
+    mathTest_all_aad(0.3, std::abs(0.3), 1.0, 0.0, sabsAD);
+    mathTest_all_aad(-0.3, std::abs(-0.3), -1.0, 0.0, sabsAD);
+    mathTest_all_aad(0.0, std::abs(0.0), 0.0, 4. / c, sabsAD);
 }
 
 LOCAL_TEST_FUNCTOR1(sabsExpr, smooth_abs(2.3 * x))
 TEST(ExpressionsMath, sabsExpr)
 {
-    mathTest_all(0.3, std::abs(2.3 * 0.3), 2.3, 0.0, sabsExpr);
-    mathTest_all(-0.3, std::abs(2.3 * -0.3), -2.3, 0.0, sabsExpr);
+    mathTest_all_aad(0.3, std::abs(2.3 * 0.3), 2.3, 0.0, sabsExpr);
+    mathTest_all_aad(-0.3, std::abs(2.3 * -0.3), -2.3, 0.0, sabsExpr);
     double c = 0.001;
-    mathTest_all(0.0, std::abs(2.3 * 0.0), 0.0, 2.3 * 2.3 * 4. / c, sabsExpr);
+    mathTest_all_aad(0.0, std::abs(2.3 * 0.0), 0.0, 2.3 * 2.3 * 4. / c, sabsExpr);
 }
 
 LOCAL_TEST_FUNCTOR2(sabsADAD, smooth_abs(x1, x2))
 TEST(ExpressionsMath, sabsADAD)
 {
-    mathTest2_all(0.3, 0.001, 0.3, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, sabsADAD);
-    mathTest2_all(-0.3, 0.001, 0.3, -1.0, 0.0, 0.0, 0.0, 0.0, 0.0, sabsADAD);
-    mathTest2_all(0.0, 0.001, 0.0, 0.0, 0.0, 4. / 0.001, 0.0, 0.0, 0.0, sabsADAD);
+    mathTest2_all_aad(0.3, 0.001, 0.3, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, sabsADAD);
+    mathTest2_all_aad(-0.3, 0.001, 0.3, -1.0, 0.0, 0.0, 0.0, 0.0, 0.0, sabsADAD);
+    mathTest2_all_aad(0.0, 0.001, 0.0, 0.0, 0.0, 4. / 0.001, 0.0, 0.0, 0.0, sabsADAD);
 }
 
 LOCAL_TEST_FUNCTOR2(sabsADExpr, smooth_abs(x1, 2.3 * x2))
 TEST(ExpressionsMath, sabsADExpr)
 {
-    mathTest2_all(0.3, 0.001, 0.3, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, sabsADExpr);
-    mathTest2_all(-0.3, 0.001, 0.3, -1.0, 0.0, 0.0, 0.0, 0.0, 0.0, sabsADExpr);
-    mathTest2_all(0.0, 0.001, 0.0, 0.0, 0.0, 4. / 2.3 / 0.001, 0.0, 0.0, 0.0, sabsADExpr);
+    mathTest2_all_aad(0.3, 0.001, 0.3, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, sabsADExpr);
+    mathTest2_all_aad(-0.3, 0.001, 0.3, -1.0, 0.0, 0.0, 0.0, 0.0, 0.0, sabsADExpr);
+    mathTest2_all_aad(0.0, 0.001, 0.0, 0.0, 0.0, 4. / 2.3 / 0.001, 0.0, 0.0, 0.0, sabsADExpr);
 }
 
 LOCAL_TEST_FUNCTOR2(sabsExprAD, smooth_abs(2.3 * x1, x2))
 TEST(ExpressionsMath, sabsExprAD)
 {
-    mathTest2_all(0.3, 0.001, 2.3 * 0.3, 2.3, 0.0, 0.0, 0.0, 0.0, 0.0, sabsExprAD);
-    mathTest2_all(-0.3, 0.001, 2.3 * 0.3, -2.3, 0.0, 0.0, 0.0, 0.0, 0.0, sabsExprAD);
-    mathTest2_all(0.0, 0.001, 0.0, 0.0, 0.0, 2.3 * 2.3 * 4. / 0.001, 0.0, 0.0, 0.0, sabsExprAD);
+    mathTest2_all_aad(0.3, 0.001, 2.3 * 0.3, 2.3, 0.0, 0.0, 0.0, 0.0, 0.0, sabsExprAD);
+    mathTest2_all_aad(-0.3, 0.001, 2.3 * 0.3, -2.3, 0.0, 0.0, 0.0, 0.0, 0.0, sabsExprAD);
+    mathTest2_all_aad(0.0, 0.001, 0.0, 0.0, 0.0, 2.3 * 2.3 * 4. / 0.001, 0.0, 0.0, 0.0, sabsExprAD);
 }
 
 LOCAL_TEST_FUNCTOR2(sabsExprExpr, smooth_abs(2.3 * x1, 2.3 * x2))
 TEST(ExpressionsMath, sabsExprExpr)
 {
-    mathTest2_all(0.3, 0.001, 2.3 * 0.3, 2.3, 0.0, 0.0, 0.0, 0.0, 0.0, sabsExprExpr);
-    mathTest2_all(-0.3, 0.001, 2.3 * 0.3, -2.3, 0.0, 0.0, 0.0, 0.0, 0.0, sabsExprExpr);
-    mathTest2_all(0.0, 0.001, 0.0, 0.0, 0.0, 2.3 * 2.3 * 4. / 2.3 / 0.001, 0.0, 0.0, 0.0,
-                  sabsExprExpr);
+    mathTest2_all_aad(0.3, 0.001, 2.3 * 0.3, 2.3, 0.0, 0.0, 0.0, 0.0, 0.0, sabsExprExpr);
+    mathTest2_all_aad(-0.3, 0.001, 2.3 * 0.3, -2.3, 0.0, 0.0, 0.0, 0.0, 0.0, sabsExprExpr);
+    mathTest2_all_aad(0.0, 0.001, 0.0, 0.0, 0.0, 2.3 * 2.3 * 4. / 2.3 / 0.001, 0.0, 0.0, 0.0,
+                      sabsExprExpr);
 }
 
 LOCAL_TEST_FUNCTOR1(floorAD, floor(x))
@@ -413,13 +412,13 @@ TEST(ExpressionsMath, remquo_AD)
 {
     int n;
     auto res = std::remquo(1.3, 0.5, &n);
-    mathTest2_all(1.3, 0.5, res, 1.0, -double(n), 0.0, 0.0, 0.0, 0.0, remquoAD);
+    mathTest2_all_aad(1.3, 0.5, res, 1.0, -double(n), 0.0, 0.0, 0.0, 0.0, remquoAD);
     EXPECT_EQ(n, rmqn_);
     rmqn_ = 0;
-    mathTest_all(1.3, res, 1.0, 0.0, remquoADScalar);
+    mathTest_all_aad(1.3, res, 1.0, 0.0, remquoADScalar);
     EXPECT_EQ(n, rmqn_);
     rmqn_ = 0;
-    mathTest_all(0.5, res, -double(n), 0.0, remquoScalarAD);
+    mathTest_all_aad(0.5, res, -double(n), 0.0, remquoScalarAD);
     EXPECT_EQ(n, rmqn_);
     rmqn_ = 0;
 }
@@ -435,19 +434,19 @@ TEST(ExpressionsMath, remquo_Expr)
     auto r1 = std::remquo(2.3 * 1.3, 2.3 * 0.5, &n1);
     auto r2 = std::remquo(1.3, 2.3 * 0.5, &n2);
     auto r3 = std::remquo(2.3 * 1.3, 0.5, &n3);
-    mathTest2_all(1.3, 0.5, r1, 2.3, -2.3 * double(n1), 0.0, 0.0, 0.0, 0.0, remquoExprExpr);
+    mathTest2_all_aad(1.3, 0.5, r1, 2.3, -2.3 * double(n1), 0.0, 0.0, 0.0, 0.0, remquoExprExpr);
     EXPECT_EQ(n1, rmqn_);
     rmqn_ = 0;
-    mathTest2_all(1.3, 0.5, r2, 1.0, -2.3 * double(n2), 0.0, 0.0, 0.0, 0.0, remquoADExpr);
+    mathTest2_all_aad(1.3, 0.5, r2, 1.0, -2.3 * double(n2), 0.0, 0.0, 0.0, 0.0, remquoADExpr);
     EXPECT_EQ(n2, rmqn_);
     rmqn_ = 0;
-    mathTest2_all(1.3, 0.5, r3, 2.3, -double(n3), 0.0, 0.0, 0.0, 0.0, remquoExprAD);
+    mathTest2_all_aad(1.3, 0.5, r3, 2.3, -double(n3), 0.0, 0.0, 0.0, 0.0, remquoExprAD);
     EXPECT_EQ(n3, rmqn_);
     rmqn_ = 0;
-    mathTest_all(1.3, r3, 2.3, 0.0, remquoExprScalar);
+    mathTest_all_aad(1.3, r3, 2.3, 0.0, remquoExprScalar);
     EXPECT_EQ(n3, rmqn_);
     rmqn_ = 0;
-    mathTest_all(0.5, r2, -2.3 * double(n2), 0.0, remquoScalarExpr);
+    mathTest_all_aad(0.5, r2, -2.3 * double(n2), 0.0, remquoScalarExpr);
     EXPECT_EQ(n2, rmqn_);
     rmqn_ = 0;
 }

--- a/test/ExpressionMath3_test.cpp
+++ b/test/ExpressionMath3_test.cpp
@@ -596,7 +596,7 @@ TEST(ExpressionsMath, modfExprScalar)
 
 struct testFunctor_copysignScalar
 {
-    testFunctor_copysignScalar(double op2) : op2_(op2) {}
+    explicit testFunctor_copysignScalar(double op2) : op2_(op2) {}
     double op2_ = 0.0;
     template <class T>
     T operator()(const T& x) const

--- a/test/ExpressionMath3_test.cpp
+++ b/test/ExpressionMath3_test.cpp
@@ -187,72 +187,73 @@ TEST(ExpressionsMath, maxExprScalar)
 LOCAL_TEST_FUNCTOR2(smaxADAD, smooth_max(x1, x2))
 TEST(ExpressionsMath, smaxADAD)
 {
-    mathTest2_all(0.3, 0.7, 0.7, 0, 1.0, 0.0, 0.0, 0.0, 0.0, smaxADAD);
-    mathTest2_all(1.7, -0.7, 1.7, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, smaxADAD);
+    mathTest2_all_aad(0.3, 0.7, 0.7, 0, 1.0, 0.0, 0.0, 0.0, 0.0, smaxADAD);
+    mathTest2_all_aad(1.7, -0.7, 1.7, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, smaxADAD);
     double c = 0.001;
-    mathTest2_all(1.7, 1.7, 1.7, 0.5, 0.5, 4. / 2. / c, -2. / c, -2. / c, 4. / 2. / c, smaxADAD);
+    mathTest2_all_aad(1.7, 1.7, 1.7, 0.5, 0.5, 4. / 2. / c, -2. / c, -2. / c, 4. / 2. / c,
+                      smaxADAD);
 }
 
 LOCAL_TEST_FUNCTOR2(smaxADExpr, smooth_max(x1, 2.0 * x2))
 TEST(ExpressionsMath, smaxADExpr)
 {
-    mathTest2_all(0.3, 0.7, 2.0 * 0.7, 0, 2.0, 0.0, 0.0, 0.0, 0.0, smaxADExpr);
-    mathTest2_all(1.7, -0.7, 1.7, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, smaxADExpr);
+    mathTest2_all_aad(0.3, 0.7, 2.0 * 0.7, 0, 2.0, 0.0, 0.0, 0.0, 0.0, smaxADExpr);
+    mathTest2_all_aad(1.7, -0.7, 1.7, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, smaxADExpr);
     double c = 0.001;
-    mathTest2_all(2.0, 1.0, 2.0, 0.5, 1.0, 4. / 2. / c, 2. * -2. / c, 2. * -2. / c,
-                  2. * 2. * 4. / 2. / c, smaxADExpr);
+    mathTest2_all_aad(2.0, 1.0, 2.0, 0.5, 1.0, 4. / 2. / c, 2. * -2. / c, 2. * -2. / c,
+                      2. * 2. * 4. / 2. / c, smaxADExpr);
 }
 
 LOCAL_TEST_FUNCTOR2(smaxExprAD, smooth_max(2.0 * x1, x2))
 TEST(ExpressionsMath, smaxExprAD)
 {
-    mathTest2_all(0.3, 0.7, 0.7, 0, 1.0, 0.0, 0.0, 0.0, 0.0, smaxExprAD);
-    mathTest2_all(1.7, -0.7, 2.0 * 1.7, 2.0, 0.0, 0.0, 0.0, 0.0, 0.0, smaxExprAD);
+    mathTest2_all_aad(0.3, 0.7, 0.7, 0, 1.0, 0.0, 0.0, 0.0, 0.0, smaxExprAD);
+    mathTest2_all_aad(1.7, -0.7, 2.0 * 1.7, 2.0, 0.0, 0.0, 0.0, 0.0, 0.0, smaxExprAD);
     double c = 0.001;
-    mathTest2_all(1.0, 2.0, 2.0, 1.0, 0.5, 2. * 2. * 4. / 2. / c, 2. * -2. / c, 2. * -2. / c,
-                  4. / 2. / c, smaxExprAD);
+    mathTest2_all_aad(1.0, 2.0, 2.0, 1.0, 0.5, 2. * 2. * 4. / 2. / c, 2. * -2. / c, 2. * -2. / c,
+                      4. / 2. / c, smaxExprAD);
 }
 
 LOCAL_TEST_FUNCTOR2(smaxExprExpr, smooth_max(2.0 * x1, 2.0 * x2))
 TEST(ExpressionsMath, smaxExprExpr)
 {
-    mathTest2_all(0.3, 0.7, 2.0 * 0.7, 0, 2.0, 0.0, 0.0, 0.0, 0.0, smaxExprExpr);
-    mathTest2_all(1.7, -0.7, 2.0 * 1.7, 2.0, 0.0, 0.0, 0.0, 0.0, 0.0, smaxExprExpr);
+    mathTest2_all_aad(0.3, 0.7, 2.0 * 0.7, 0, 2.0, 0.0, 0.0, 0.0, 0.0, smaxExprExpr);
+    mathTest2_all_aad(1.7, -0.7, 2.0 * 1.7, 2.0, 0.0, 0.0, 0.0, 0.0, 0.0, smaxExprExpr);
     double c = 0.001;
-    mathTest2_all(1.0, 1.0, 2.0, 1.0, 1.0, 2. * 2. * 4. / 2. / c, 2. * 2. * -2. / c,
-                  2. * 2. * -2. / c, 2. * 2. * 4. / 2. / c, smaxExprExpr);
+    mathTest2_all_aad(1.0, 1.0, 2.0, 1.0, 1.0, 2. * 2. * 4. / 2. / c, 2. * 2. * -2. / c,
+                      2. * 2. * -2. / c, 2. * 2. * 4. / 2. / c, smaxExprExpr);
 }
 
 LOCAL_TEST_FUNCTOR1(smaxScalarAD, smooth_max(0.7, x))
 TEST(ExpressionsMath, smaxScalarAD)
 {
-    mathTest_all(1.1, 1.1, 1.0, 0.0, smaxScalarAD);
-    mathTest_all(0.6, 0.7, 0.0, 0.0, smaxScalarAD);
+    mathTest_all_aad(1.1, 1.1, 1.0, 0.0, smaxScalarAD);
+    mathTest_all_aad(0.6, 0.7, 0.0, 0.0, smaxScalarAD);
 }
 
 LOCAL_TEST_FUNCTOR1(smaxScalarExpr, smooth_max(2.0, 2.0 * x))
 TEST(ExpressionsMath, smaxScalarExpr)
 {
     double c = 0.001;
-    mathTest_all(1.1, 2.2, 2.0, 0.0, smaxScalarExpr);
-    mathTest_all(1.0, 2.0, 1.0, 2. * 2. * 4. / 2. / c, smaxScalarExpr);
-    mathTest_all(0.3, 2.0, 0.0, 0.0, smaxScalarExpr);
+    mathTest_all_aad(1.1, 2.2, 2.0, 0.0, smaxScalarExpr);
+    mathTest_all_aad(1.0, 2.0, 1.0, 2. * 2. * 4. / 2. / c, smaxScalarExpr);
+    mathTest_all_aad(0.3, 2.0, 0.0, 0.0, smaxScalarExpr);
 }
 
 LOCAL_TEST_FUNCTOR1(smaxADScalar, smooth_max(x, 0.7))
 TEST(ExpressionsMath, smaxADScalar)
 {
-    mathTest_all(1.1, 1.1, 1.0, 0.0, smaxADScalar);
-    mathTest_all(0.6, 0.7, 0.0, 0.0, smaxADScalar);
+    mathTest_all_aad(1.1, 1.1, 1.0, 0.0, smaxADScalar);
+    mathTest_all_aad(0.6, 0.7, 0.0, 0.0, smaxADScalar);
 }
 
 LOCAL_TEST_FUNCTOR1(smaxExprScalar, smooth_max(2.0 * x, 2.0))
 TEST(ExpressionsMath, smaxExprScalar)
 {
     double c = 0.001;
-    mathTest_all(1.1, 2.2, 2.0, 0.0, smaxExprScalar);
-    mathTest_all(1.0, 2.0, 1.0, 2. * 2. * 4. / 2. / c, smaxExprScalar);
-    mathTest_all(0.3, 2.0, 0.0, 0.0, smaxExprScalar);
+    mathTest_all_aad(1.1, 2.2, 2.0, 0.0, smaxExprScalar);
+    mathTest_all_aad(1.0, 2.0, 1.0, 2. * 2. * 4. / 2. / c, smaxExprScalar);
+    mathTest_all_aad(0.3, 2.0, 0.0, 0.0, smaxExprScalar);
 }
 
 LOCAL_TEST_FUNCTOR2(minADAD, min(x1, x2))
@@ -329,72 +330,72 @@ TEST(ExpressionsMath, minExprScalar)
 LOCAL_TEST_FUNCTOR2(sminADAD, smooth_min(x1, x2))
 TEST(ExpressionsMath, sminADAD)
 {
-    mathTest2_all(0.3, 0.7, 0.3, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, sminADAD);
-    mathTest2_all(1.7, -0.7, -0.7, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, sminADAD);
+    mathTest2_all_aad(0.3, 0.7, 0.3, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, sminADAD);
+    mathTest2_all_aad(1.7, -0.7, -0.7, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, sminADAD);
     double c = 0.001;
-    mathTest2_all(1.7, 1.7, 1.7, 0.5, 0.5, -2. / c, 2. / c, 2. / c, -2. / c, sminADAD);
+    mathTest2_all_aad(1.7, 1.7, 1.7, 0.5, 0.5, -2. / c, 2. / c, 2. / c, -2. / c, sminADAD);
 }
 
 LOCAL_TEST_FUNCTOR2(sminADExpr, smooth_min(x1, 2.0 * x2))
 TEST(ExpressionsMath, sminADExpr)
 {
-    mathTest2_all(0.3, 0.7, 0.3, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, sminADExpr);
-    mathTest2_all(1.7, -0.7, 2.0 * -0.7, 0.0, 2.0, 0.0, 0.0, 0.0, 0.0, sminADExpr);
+    mathTest2_all_aad(0.3, 0.7, 0.3, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, sminADExpr);
+    mathTest2_all_aad(1.7, -0.7, 2.0 * -0.7, 0.0, 2.0, 0.0, 0.0, 0.0, 0.0, sminADExpr);
     double c = 0.001;
-    mathTest2_all(2.0, 1.0, 2.0, 0.5, 1.0, -2. / c, 2. * 2. / c, 2. * 2. / c, 2. * 2. * -2. / c,
-                  sminADExpr);
+    mathTest2_all_aad(2.0, 1.0, 2.0, 0.5, 1.0, -2. / c, 2. * 2. / c, 2. * 2. / c, 2. * 2. * -2. / c,
+                      sminADExpr);
 }
 
 LOCAL_TEST_FUNCTOR2(sminExprAD, smooth_min(2.0 * x1, x2))
 TEST(ExpressionsMath, sminExprAD)
 {
-    mathTest2_all(0.3, 0.7, 2.0 * 0.3, 2.0, 0.0, 0.0, 0.0, 0.0, 0.0, sminExprAD);
-    mathTest2_all(1.7, -0.7, -0.7, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, sminExprAD);
+    mathTest2_all_aad(0.3, 0.7, 2.0 * 0.3, 2.0, 0.0, 0.0, 0.0, 0.0, 0.0, sminExprAD);
+    mathTest2_all_aad(1.7, -0.7, -0.7, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, sminExprAD);
     double c = 0.001;
-    mathTest2_all(1.0, 2.0, 2.0, 1.0, 0.5, 2. * 2. * -2. / c, 2. * 2. / c, 2. * 2. / c, -2. / c,
-                  sminExprAD);
+    mathTest2_all_aad(1.0, 2.0, 2.0, 1.0, 0.5, 2. * 2. * -2. / c, 2. * 2. / c, 2. * 2. / c, -2. / c,
+                      sminExprAD);
 }
 
 LOCAL_TEST_FUNCTOR2(sminExprExpr, smooth_min(2.0 * x1, 2.0 * x2))
 TEST(ExpressionsMath, sminExprExpr)
 {
-    mathTest2_all(0.3, 0.7, 2.0 * 0.3, 2.0, 0.0, 0.0, 0.0, 0.0, 0.0, sminExprExpr);
-    mathTest2_all(1.7, -0.7, 2.0 * -0.7, 0.0, 2.0, 0.0, 0.0, 0.0, 0.0, sminExprExpr);
+    mathTest2_all_aad(0.3, 0.7, 2.0 * 0.3, 2.0, 0.0, 0.0, 0.0, 0.0, 0.0, sminExprExpr);
+    mathTest2_all_aad(1.7, -0.7, 2.0 * -0.7, 0.0, 2.0, 0.0, 0.0, 0.0, 0.0, sminExprExpr);
     double c = 0.001;
-    mathTest2_all(1.0, 1.0, 2.0, 1.0, 1.0, 2. * 2. * -2. / c, 2. * -2. * -2. / c,
-                  2. * -2. * -2. / c, 2. * 2. * -2. / c, sminExprExpr);
+    mathTest2_all_aad(1.0, 1.0, 2.0, 1.0, 1.0, 2. * 2. * -2. / c, 2. * -2. * -2. / c,
+                      2. * -2. * -2. / c, 2. * 2. * -2. / c, sminExprExpr);
 }
 
 LOCAL_TEST_FUNCTOR1(sminScalarAD, smooth_min(0.7, x))
 TEST(ExpressionsMath, sminScalarAD)
 {
-    mathTest_all(1.1, 0.7, 0.0, 0.0, sminScalarAD);
-    mathTest_all(0.6, 0.6, 1.0, 0.0, sminScalarAD);
+    mathTest_all_aad(1.1, 0.7, 0.0, 0.0, sminScalarAD);
+    mathTest_all_aad(0.6, 0.6, 1.0, 0.0, sminScalarAD);
 }
 
 LOCAL_TEST_FUNCTOR1(sminScalarExpr, smooth_min(2.0, 2.0 * x))
 TEST(ExpressionsMath, sminScalarExpr)
 {
-    mathTest_all(1.1, 2.0, 0.0, 0.0, sminScalarExpr);
-    mathTest_all(0.9, 1.8, 2.0, 0.0, sminScalarExpr);
+    mathTest_all_aad(1.1, 2.0, 0.0, 0.0, sminScalarExpr);
+    mathTest_all_aad(0.9, 1.8, 2.0, 0.0, sminScalarExpr);
     double c = 0.001;
-    mathTest_all(1.0, 2.0, 1.0, -2. * 2. * 2. / c, sminScalarExpr);
+    mathTest_all_aad(1.0, 2.0, 1.0, -2. * 2. * 2. / c, sminScalarExpr);
 }
 
 LOCAL_TEST_FUNCTOR1(sminADScalar, smooth_min(x, 0.7))
 TEST(ExpressionsMath, sminADScalar)
 {
-    mathTest_all(1.1, 0.7, 0.0, 0.0, sminADScalar);
-    mathTest_all(0.6, 0.6, 1.0, 0.0, sminADScalar);
+    mathTest_all_aad(1.1, 0.7, 0.0, 0.0, sminADScalar);
+    mathTest_all_aad(0.6, 0.6, 1.0, 0.0, sminADScalar);
 }
 
 LOCAL_TEST_FUNCTOR1(sminExprScalar, smooth_min(2.0 * x, 2.0))
 TEST(ExpressionsMath, sminExprScalar)
 {
-    mathTest_all(1.1, 2.0, 0.0, 0.0, sminExprScalar);
-    mathTest_all(0.9, 1.8, 2.0, 0.0, sminExprScalar);
+    mathTest_all_aad(1.1, 2.0, 0.0, 0.0, sminExprScalar);
+    mathTest_all_aad(0.9, 1.8, 2.0, 0.0, sminExprScalar);
     double c = 0.001;
-    mathTest_all(1.0, 2.0, 1.0, -2. * 2. * 2. / c, sminExprScalar);
+    mathTest_all_aad(1.0, 2.0, 1.0, -2. * 2. * 2. / c, sminExprScalar);
 }
 
 // make sure that max/min in std namespace are still working for integer and
@@ -462,18 +463,18 @@ TEST(ExpressionsMath, maxMinForIntegersExplicit)
 
 // temporarily disable double->int conversion warning, as we're testing just that below
 #if defined(_MSC_VER)
-#  pragma warning(push)
-#  pragma warning(disable : 4244)
+#pragma warning(push)
+#pragma warning(disable : 4244)
 #elif defined(__GNUC__)
-#  pragma GCC diagnostic push
-#  if (__GNUC__ < 5) && !defined(__clang__)
-#    pragma GCC diagnostic ignored "-Wconversion"
-#  else
-#    pragma GCC diagnostic ignored "-Wfloat-conversion"
-#  endif
+#pragma GCC diagnostic push
+#if (__GNUC__ < 5) && !defined(__clang__)
+#pragma GCC diagnostic ignored "-Wconversion"
+#else
+#pragma GCC diagnostic ignored "-Wfloat-conversion"
+#endif
 #elif defined(__clang__)
-#  pragma clang diagnostic push
-#  pragma clang diagnostic ignored "-Wfloat-conversion"
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wfloat-conversion"
 #endif
 
 TEST(ExpressionsMath, maxMinForIntegersDoubleExplicit)
@@ -591,4 +592,23 @@ TEST(ExpressionsMath, modfExprScalar)
 {
     mathTest_all(1.2, 0.2, 1.0, 0.0, modfExprScalar);
     EXPECT_NEAR(testFunctor_modfExprScalar::ipart, 1.0, 1e-9);
+}
+
+TEST(ExpressionsMath, copysignADScalar)
+{
+    mathTest_all(1.2, 1.2, 1.0, 0.0, [](auto& x) { return copysign(x, 5.9); });
+    mathTest_all(1.2, 1.2, 1.0, 0.0, [](auto& x) { return copysign(x, 0.0); });
+    mathTest_all(1.2, -1.2, -1.0, 0.0, [](auto& x) { return copysign(x, -5.9); });
+    mathTest_all(1.2, -1.2, -1.0, 0.0, [](auto& x) { return copysign(x, -0.0000001); });
+}
+
+TEST(ExpressionsMath, copysignADAD)
+{
+    mathTest_all(1.2, 1.2, 1.0, 0.0, [](auto& x) { return copysign(x, x); });
+    mathTest_all(-1.2, -1.2, 1.0, 0.0, [](auto& x) { return copysign(x, x); });
+    mathTest_all(1.2, -1.2, -1.0, 0.0, [](auto& x) { return copysign(x, -x); });
+    mathTest_all(1.2, -1.2, -1.0, 0.0, [](auto& x) { return copysign(x, -x - 1); });
+    mathTest_all(1.2, -1.2, -1.0, 0.0, [](auto& x) { return copysign(x, -x * x); });
+    mathTest_all(1.2, -1.2, -1.0, 0.0, [](auto& x) { return copysign(-x, -x); });
+    mathTest_all(1.2, -2.4, -2.0, 0.0, [](auto& x) { return copysign(-x * 2, -x); });
 }

--- a/test/ExpressionMath3_test.cpp
+++ b/test/ExpressionMath3_test.cpp
@@ -594,21 +594,69 @@ TEST(ExpressionsMath, modfExprScalar)
     EXPECT_NEAR(testFunctor_modfExprScalar::ipart, 1.0, 1e-9);
 }
 
+struct testFunctor_copysignScalar
+{
+    testFunctor_copysignScalar(double op2) : op2_(op2) {}
+    double op2_ = 0.0;
+    template <class T>
+    T operator()(const T& x) const
+    {
+        return copysign(x, op2_);
+    }
+};
+
 TEST(ExpressionsMath, copysignADScalar)
 {
-    mathTest_all(1.2, 1.2, 1.0, 0.0, [](auto& x) { return copysign(x, 5.9); });
-    mathTest_all(1.2, 1.2, 1.0, 0.0, [](auto& x) { return copysign(x, 0.0); });
-    mathTest_all(1.2, -1.2, -1.0, 0.0, [](auto& x) { return copysign(x, -5.9); });
-    mathTest_all(1.2, -1.2, -1.0, 0.0, [](auto& x) { return copysign(x, -0.0000001); });
+    mathTest_all(1.2, 1.2, 1.0, 0.0, testFunctor_copysignScalar(5.9));
+    mathTest_all(1.2, 1.2, 1.0, 0.0, testFunctor_copysignScalar(0.0));
+    mathTest_all(1.2, -1.2, -1.0, 0.0, testFunctor_copysignScalar(-5.9));
+    mathTest_all(1.2, -1.2, -1.0, 0.0, testFunctor_copysignScalar(-0.0000001));
 }
+
+struct testFunctor_copysignAD
+{
+    template <class T>
+    T operator()(const T& x) const
+    {
+        return copysign(x, x);
+    }
+} copysignAD;
 
 TEST(ExpressionsMath, copysignADAD)
 {
-    mathTest_all(1.2, 1.2, 1.0, 0.0, [](auto& x) { return copysign(x, x); });
-    mathTest_all(-1.2, -1.2, 1.0, 0.0, [](auto& x) { return copysign(x, x); });
-    mathTest_all(1.2, -1.2, -1.0, 0.0, [](auto& x) { return copysign(x, -x); });
-    mathTest_all(1.2, -1.2, -1.0, 0.0, [](auto& x) { return copysign(x, -x - 1); });
-    mathTest_all(1.2, -1.2, -1.0, 0.0, [](auto& x) { return copysign(x, -x * x); });
-    mathTest_all(1.2, -1.2, -1.0, 0.0, [](auto& x) { return copysign(-x, -x); });
-    mathTest_all(1.2, -2.4, -2.0, 0.0, [](auto& x) { return copysign(-x * 2, -x); });
+    mathTest_all(1.2, 1.2, 1.0, 0.0, copysignAD);
+    mathTest_all(-1.2, -1.2, 1.0, 0.0, copysignAD);
 }
+
+struct testFunctor_copysignADExpr
+{
+    template <class T>
+    T operator()(const T& x) const
+    {
+        return copysign(x, -x);
+    }
+} copysignADExpr;
+
+TEST(ExpressionsMath, copysignADExpr) { mathTest_all(1.2, -1.2, -1.0, 0.0, copysignADExpr); }
+
+struct testFunctor_copysignExprAD
+{
+    template <class T>
+    T operator()(const T& x) const
+    {
+        return copysign(-x, x);
+    }
+} copysignExprAD;
+
+TEST(ExpressionsMath, copysignExprAD) { mathTest_all(1.2, 1.2, 1.0, 0.0, copysignExprAD); }
+
+struct testFunctor_copysignExprExpr
+{
+    template <class T>
+    T operator()(const T& x) const
+    {
+        return copysign(-x, -x);
+    }
+} copysignExprExpr;
+
+TEST(ExpressionsMath, copysignExprExpr) { mathTest_all(1.2, -1.2, -1.0, 0.0, copysignExprExpr); }

--- a/test/StdCompatibility_test.cpp
+++ b/test/StdCompatibility_test.cpp
@@ -101,6 +101,7 @@ TEST(StdCompatibility, canUseStdMath)
     EXPECT_THAT(std::signbit(x), Eq(std::signbit(xd)));
     EXPECT_THAT(std::fpclassify(x), Eq(std::fpclassify(xd)));
     EXPECT_THAT(std::ilogb(x), Eq(std::ilogb(xd)));
+    EXPECT_THAT(std::copysign(x, -x), Eq(std::copysign(xd, -xd)));
 
     // complex
     EXPECT_THAT(std::real(x).getValue(), DoubleNear(std::real(xd), 1e-9));

--- a/test/TestHelpers.hpp
+++ b/test/TestHelpers.hpp
@@ -40,6 +40,13 @@ inline void compareFinite(double xref, double xact, const std::string& msg = "")
 }
 
 template <class F>
+inline void mathTest_dbl(double x, double yref, F func)
+{
+    double y = func(x);
+    EXPECT_DOUBLE_EQ(y, yref) << "dbl, yref";
+}
+
+template <class F>
 inline void mathTest_adj(double x, double yref, double dref, F func)
 {
     xad::Tape<double> s;
@@ -101,7 +108,7 @@ inline void mathTest_adj_adj(double x, double yref, double dref1, double dref2, 
 
     so.registerOutput(y);
     derivative(y) = 1.0;
-    
+
     so.computeAdjoints();
 
     si.registerOutput(derivative(x1));
@@ -158,7 +165,7 @@ inline void mathTest_adj_fwd(double x, double yref, double dref1, double dref2, 
 }
 
 template <class F>
-inline void mathTest_all(double x, double yref, double dref, double dref2, F func)
+inline void mathTest_all_aad(double x, double yref, double dref, double dref2, F func)
 {
     mathTest_adj(x, yref, dref, func);
     mathTest_fwd(x, yref, dref, func);
@@ -166,6 +173,20 @@ inline void mathTest_all(double x, double yref, double dref, double dref2, F fun
     mathTest_fwd_adj(x, yref, dref, dref2, func);
     mathTest_adj_fwd(x, yref, dref, dref2, func);
     mathTest_adj_adj(x, yref, dref, dref2, func);
+}
+
+template <class F>
+inline void mathTest_all(double x, double yref, double dref, double dref2, F func)
+{
+    mathTest_dbl(x, yref, func);
+    mathTest_all_aad(x, yref, dref, dref2, func);
+}
+
+template <class F>
+inline void mathTest2_dbl(double x1, double x2, double yref, F func)
+{
+    double y = func(x1, x2);
+    EXPECT_DOUBLE_EQ(y, yref);
 }
 
 template <class F>
@@ -426,8 +447,8 @@ inline void mathTest2_adj_adj(double x1, double x2, double yref, double d1ref, d
 }
 
 template <class F>
-inline void mathTest2_all(double x1, double x2, double yref, double d1ref, double d2ref,
-                          double d11ref, double d12ref, double d21ref, double d22ref, F func)
+inline void mathTest2_all_aad(double x1, double x2, double yref, double d1ref, double d2ref,
+                              double d11ref, double d12ref, double d21ref, double d22ref, F func)
 {
     mathTest2_adj(x1, x2, yref, d1ref, d2ref, func);
     mathTest2_fwd(x1, x2, yref, d1ref, d2ref, func);
@@ -437,12 +458,21 @@ inline void mathTest2_all(double x1, double x2, double yref, double d1ref, doubl
     mathTest2_adj_adj(x1, x2, yref, d1ref, d2ref, d11ref, d12ref, d21ref, d22ref, func);
 }
 
+template <class F>
+inline void mathTest2_all(double x1, double x2, double yref, double d1ref, double d2ref,
+                          double d11ref, double d12ref, double d21ref, double d22ref, F func)
+{
+    mathTest2_dbl(x1, x2, yref, func);
+    mathTest2_all_aad(x1, x2, yref, d1ref, d2ref, d11ref, d12ref, d21ref, d22ref, func);
+}
+
 #define LOCAL_TEST_FUNCTOR1(name, val)                                                             \
     struct testFunctor_##name                                                                      \
     {                                                                                              \
         template <class T>                                                                         \
         T operator()(const T& x) const                                                             \
         {                                                                                          \
+            using namespace std;                                                                   \
             return val;                                                                            \
         }                                                                                          \
     } name;
@@ -453,6 +483,7 @@ inline void mathTest2_all(double x1, double x2, double yref, double d1ref, doubl
         template <class T>                                                                         \
         T operator()(const T& x1, const T& x2) const                                               \
         {                                                                                          \
+            using namespace std;                                                                   \
             return val;                                                                            \
         }                                                                                          \
     } name;


### PR DESCRIPTION
# Description

This adds the `copysign` math function into the `xad` namespace, including tracking derivatives. This function was missing from XAD. It is implemented using `signbit`, which was already present.

Further, it improves the test infrastructure to also test the math reference output using the plain double implementation, giving more confidence that the reference value is given correctly in the tests and that the XAD version indeed matches the standard library one.

## Type of change

- New feature (non-breaking change which adds functionality)
- Includes a documentation update
