### PR TITLE
Enable copysign(double, <AD>) type of expressions

### DIFF
--- a/src/XAD/UnaryOperators.hpp
+++ b/src/XAD/UnaryOperators.hpp
@@ -475,6 +475,20 @@ XAD_INLINE typename ExprTraits<Derived>::value_type copysign(const Expression<Sc
     }
 }
 
+template <class Scalar, class Derived>
+XAD_INLINE double copysign(double x, const Expression<Scalar, Derived>& y) 
+{
+    using std::copysign;
+    return copysign(x, value(y));
+}
+
+template <class Scalar, class Derived>
+XAD_INLINE float copysign(float x, const Expression<Scalar, Derived>& y) 
+{
+    using std::copysign;
+    return copysign(x, value(y));
+}
+
 #undef XAD_UNARY_BINSCAL
 #undef XAD_UNARY_BINSCAL1
 #undef XAD_UNARY_BINSCAL2

--- a/test/ExpressionMath3_test.cpp
+++ b/test/ExpressionMath3_test.cpp
@@ -594,9 +594,27 @@ TEST(ExpressionsMath, modfExprScalar)
     EXPECT_NEAR(testFunctor_modfExprScalar::ipart, 1.0, 1e-9);
 }
 
-struct testFunctor_copysignScalar
+
+struct testFunctor_copysignScalar1
 {
-    explicit testFunctor_copysignScalar(double op2) : op2_(op2) {}
+    explicit testFunctor_copysignScalar1(double op1) : op1_(op1) {}
+    double op1_ = 0.0;
+    template <class T>
+    double operator()(const T& x) const
+    {
+        return copysign(op1_, x);
+    }
+};
+
+TEST(ExpressionsMath, copysignScalarAD)
+{
+    mathTest_all(1.2, 42.2, 0.0, 0.0, testFunctor_copysignScalar1(42.2));
+    mathTest_all(-1.2, -42.2, 0.0, 0.0, testFunctor_copysignScalar1(42.2));
+}
+
+struct testFunctor_copysignScalar2
+{
+    explicit testFunctor_copysignScalar2(double op2) : op2_(op2) {}
     double op2_ = 0.0;
     template <class T>
     T operator()(const T& x) const
@@ -607,10 +625,10 @@ struct testFunctor_copysignScalar
 
 TEST(ExpressionsMath, copysignADScalar)
 {
-    mathTest_all(1.2, 1.2, 1.0, 0.0, testFunctor_copysignScalar(5.9));
-    mathTest_all(1.2, 1.2, 1.0, 0.0, testFunctor_copysignScalar(0.0));
-    mathTest_all(1.2, -1.2, -1.0, 0.0, testFunctor_copysignScalar(-5.9));
-    mathTest_all(1.2, -1.2, -1.0, 0.0, testFunctor_copysignScalar(-0.0000001));
+    mathTest_all(1.2, 1.2, 1.0, 0.0, testFunctor_copysignScalar2(5.9));
+    mathTest_all(1.2, 1.2, 1.0, 0.0, testFunctor_copysignScalar2(0.0));
+    mathTest_all(1.2, -1.2, -1.0, 0.0, testFunctor_copysignScalar2(-5.9));
+    mathTest_all(1.2, -1.2, -1.0, 0.0, testFunctor_copysignScalar2(-0.0000001));
 }
 
 struct testFunctor_copysignAD


### PR DESCRIPTION
# Description

In addition to the previous PR #52, this adds the capability for using copysign with a `double` or `float` value for the first argument, i.e. expressions like `copysign(1.0, x - sin(x))`, where `x` is an active XAD type or an expression. This was missing from the previous PR.

## Type of change

- New feature (non-breaking change which adds functionality)

