### PR TITLE
Fixes Codacy code quality issues - mostly markdown formatting

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,10 +1,9 @@
 ---
 name: Bug report
 about: Create a report to help us improve
-title: ''
+title: ""
 labels: bug
-assignees: ''
-
+assignees: ""
 ---
 
 **Describe the bug**
@@ -17,11 +16,12 @@ Steps or reproducer code snippets to reproduce the behaviour.
 A clear and concise description of what you expected to happen.
 
 **Environment (please complete the following information):**
- - OS: [e.g. Windows]
- - Version: [e.g. 11]
-- Compiler: [e.g. VC++ 2022]
-- IDE (if relevant): [e.g. Visual Studio 2022]
-- CMake Configuration (if not default): [e.g. `XAD_STRONG_INLINE=ON`]
+
+-   OS: (e.g. Windows)
+-   Version: (e.g. 11)
+-   Compiler: (e.g. VC++ 2022)
+-   IDE (if relevant): (e.g. Visual Studio 2022)
+-   CMake Configuration (if not default): (e.g. `XAD_STRONG_INLINE=ON`)
 
 **Additional context**
 Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -8,7 +8,7 @@ assignees: ''
 ---
 
 **Is your feature request related to a problem? Please describe.**
-A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+A clear and concise description of what the problem is. Ex. I'm always frustrated when (...)
 
 **Describe the solution you'd like**
 A clear and concise description of what you want to happen.

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -12,4 +12,3 @@
 
 To report a security vulnerability, please send an email to xad@xcelerit.com,
 describing the issue with as much detail as possible.
-

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -25,4 +25,3 @@ Please ensure that the following items have been completed and delete this secti
 -   I have commented my code, particularly in hard-to-understand areas
 -   I have made corresponding changes to the documentation, if relevant
 -   I have added tests that prove my fix is effective or that my feature works
-

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -11,16 +11,18 @@ Fixes # (issue - if relevant)
 
 Please delete options that are not relevant.
 
-- [ ] Bug fix (non-breaking change which fixes an issue)
-- [ ] New feature (non-breaking change which adds functionality)
-- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-- [ ] This change requires a documentation update
+-   Bug fix (non-breaking change which fixes an issue)
+-   New feature (non-breaking change which adds functionality)
+-   Breaking change (fix or feature that would cause existing functionality to not work as expected)
+-   This change requires a documentation update
 
-# Checklist:
+## Checklist
 
-- [ ] My code follows the [style guidelines of this project](https://github.com/xcelerit/XAD/blob/main/CONTRIBUTING.md)
-- [ ] I have performed a self-review of my code
-- [ ] I have commented my code, particularly in hard-to-understand areas
-- [ ] I have made corresponding changes to the documentation, if relevant
-- [ ] I have added tests that prove my fix is effective or that my feature works
+Please ensure that the following items have been completed and delete this section afterwards.
+
+-   My code follows the [style guidelines of this project](https://github.com/xcelerit/XAD/blob/main/CONTRIBUTING.md)
+-   I have performed a self-review of my code
+-   I have commented my code, particularly in hard-to-understand areas
+-   I have made corresponding changes to the documentation, if relevant
+-   I have added tests that prove my fix is effective or that my feature works
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,6 @@ All notable changes to XAD will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-
 ## [unreleased]
 
 ### Added
@@ -21,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 ### Fixed
+
 
 ## [1.1.0] - 2022-11-17
 
@@ -40,12 +40,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   Better use of caching in CI/CD pipelines for faster builds
 
 
-
 ## [1.0.0] - 2022-07-07
 
 Initial open-source release
-
-
 
 [unreleased]: https://github.com/xcelerit/xad/compare/v1.1.0...HEAD
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@
     </a>
 </p>
 
-
 XAD is a fast and comprehensive C++ library for automatic differentiation by Xcelerit.
 It targets production-quality code at any scale, striving for both ease of use and high performance.
 
@@ -350,7 +349,6 @@ or [submit a PR](CONTRIBUTING.md) to include it in the [CI workflow][ci].
 | Ubuntu 22.04         | Clang 13.0.1                      | Debug, Release, Release with `XAD_TAPE_REUSE_SLOTS` | no       |
 | Ubuntu 22.04         | Clang 14.0.0                      | Debug, Release, Release with `XAD_TAPE_REUSE_SLOTS` | no       |
 | MacOS 12.6.5         | AppleClang 14.0.0                 | Debug, Release                                      | yes      |
-
 
 ## Versioning
 

--- a/src/XAD/BinaryMathFunctors.hpp
+++ b/src/XAD/BinaryMathFunctors.hpp
@@ -246,7 +246,7 @@ struct remainder_op
         // function is rare enough that there's no need to optimize this better
         int n_;
         using std::remquo;
-        remquo(a, b, &n_);
+        XAD_UNUSED_VARIABLE(remquo(a, b, &n_));
         return Scalar(-n_);
     }
 };

--- a/src/XAD/ChunkContainer.hpp
+++ b/src/XAD/ChunkContainer.hpp
@@ -316,7 +316,7 @@ class ChunkContainer
         pointer point_;
         pointer next_chunk_;
         int space_left_;
-        iterator(pointer point = nullptr, int space_left = 0, pointer next = NULL)
+        explicit iterator(pointer point = nullptr, int space_left = 0, pointer next = NULL)
             : point_(point), next_chunk_(next), space_left_(space_left)
         {
         }

--- a/src/XAD/Complex.hpp
+++ b/src/XAD/Complex.hpp
@@ -2247,7 +2247,6 @@ template <class T>
 XAD_INLINE std::complex<T> atan_impl(const std::complex<T>& z)
 {
     // -i * atanh(i*z)
-    std::complex<T> complex_i(0, 1);
     std::complex<T> iz(-z.imag(), z.real());
     std::complex<T> atanhiz = atanh(iz);
     return std::complex<T>(atanhiz.imag(), -atanhiz.real());

--- a/src/XAD/Literals.hpp
+++ b/src/XAD/Literals.hpp
@@ -46,7 +46,7 @@ struct ADTypeBase : public Expression<Scalar, Derived>
 
     static_assert(std::is_floating_point<nested_type>::value, "Active AD types only work with floating point");
 
-    constexpr XAD_INLINE ADTypeBase(Scalar val = Scalar()) : a_(val) {}
+    constexpr explicit XAD_INLINE ADTypeBase(Scalar val = Scalar()) : a_(val) {}
     constexpr XAD_INLINE ADTypeBase(ADTypeBase&& o) noexcept = default;
     constexpr XAD_INLINE ADTypeBase(const ADTypeBase& o) = default;
     XAD_INLINE ADTypeBase& operator=(ADTypeBase&& o) noexcept = default;

--- a/src/XAD/ReusableRange.hpp
+++ b/src/XAD/ReusableRange.hpp
@@ -33,7 +33,7 @@ template <class T>
 class ReusableRange
 {
   public:
-    ReusableRange(T start = T(), T end = T()) : first_(start), second_(end) {}
+    explicit ReusableRange(T start = T(), T end = T()) : first_(start), second_(end) {}
     bool isClosed() const { return first_ >= second_; }
     T size() const { return second_ - first_; }
 


### PR DESCRIPTION
# Description

Codacy gave XAD a `B` in code quality, flagging a little more than 50 issues with the codebase. This was mostly for markdown formatting (incorrect spacing, blank lines, etc). This pull request fixes these, with the aim of getting back to an `A` rating.