### PR TITLE
Reformat all files according to clang-format specs

### DIFF
--- a/src/XAD/BinaryExpr.hpp
+++ b/src/XAD/BinaryExpr.hpp
@@ -30,7 +30,6 @@
 #include <XAD/Traits.hpp>
 #include <type_traits>
 
-
 namespace xad
 {
 

--- a/src/XAD/BinaryMathFunctors.hpp
+++ b/src/XAD/BinaryMathFunctors.hpp
@@ -272,7 +272,7 @@ template <class Scalar>
 struct nextafter_op
 {
     XAD_INLINE explicit nextafter_op() {}
-    XAD_INLINE Scalar operator()(const Scalar& from, const Scalar& to) const 
+    XAD_INLINE Scalar operator()(const Scalar& from, const Scalar& to) const
     {
         return nextafter(from, to);
     }

--- a/src/XAD/ChunkContainer.hpp
+++ b/src/XAD/ChunkContainer.hpp
@@ -35,22 +35,26 @@
 
 // cross-platform aligned (de-)allocation
 
-#if defined(__APPLE__) || defined(__ANDROID__) || (defined(__linux__) && defined(__GLIBCXX__) && !defined(_GLIBCXX_HAVE_ALIGNED_ALLOC))
+#if defined(__APPLE__) || defined(__ANDROID__) ||                                                  \
+    (defined(__linux__) && defined(__GLIBCXX__) && !defined(_GLIBCXX_HAVE_ALIGNED_ALLOC))
 #include <cstdlib>
 
 #if defined(__APPLE__)
 #include <AvailabilityMacros.h>
 #endif
 
-namespace xad { namespace detail {
+namespace xad
+{
+namespace detail
+{
 inline void* aligned_alloc(size_t alignment, size_t size)
 {
     if (size < alignment)
         size = alignment;
 #if defined(__APPLE__) && defined(MAC_OS_X_VERSION_10_16)
-#if MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_16 
+#if MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_16
     // For C++14, usr/include/malloc/_malloc.h declares aligned_alloc()) only
-    // with the MacOSX11.0 SDK in Xcode 12 (which is what adds 
+    // with the MacOSX11.0 SDK in Xcode 12 (which is what adds
     // MAC_OS_X_VERSION_10_16), even though the function is marked
     // availabe for 10.15. That's why the preprocessor checks for 10.16 but
     // the __builtin_available checks for 10.15.
@@ -60,45 +64,53 @@ inline void* aligned_alloc(size_t alignment, size_t size)
 #endif
 #endif
     // alignment must be >= sizeof(void*)
-    if(alignment < sizeof(void*))
+    if (alignment < sizeof(void*))
     {
         alignment = sizeof(void*);
     }
 
-    void *pointer;
-    if(posix_memalign(&pointer, alignment, size) == 0)
+    void* pointer;
+    if (posix_memalign(&pointer, alignment, size) == 0)
         return pointer;
     return nullptr;
 }
 inline void aligned_free(void* p) { free(p); }
 
-}}
+}  // namespace detail
+}  // namespace xad
 #elif defined(_WIN32)
-namespace xad { namespace detail {
-inline void *aligned_alloc(size_t alignment, size_t size)
+namespace xad
+{
+namespace detail
+{
+inline void* aligned_alloc(size_t alignment, size_t size)
 {
     if (size < alignment)
         size = alignment;
     return ::_aligned_malloc(size, alignment);
 }
 inline void aligned_free(void* p) { ::_aligned_free(p); }
-}}
+}  // namespace detail
+}  // namespace xad
 #else
-namespace xad { namespace detail {
-inline void *aligned_alloc(size_t alignment, size_t size)
+namespace xad
+{
+namespace detail
+{
+inline void* aligned_alloc(size_t alignment, size_t size)
 {
     if (size < alignment)
         size = alignment;
     return ::aligned_alloc(alignment, size);
 }
 inline void aligned_free(void* p) { free(p); }
-}}
+}  // namespace detail
+}  // namespace xad
 #endif
 
 namespace xad
 {
 
-    
 template <class T, std::size_t ChunkSize = 1024U * 1024U * 8U>
 class ChunkContainer
 {
@@ -147,8 +159,7 @@ class ChunkContainer
             for (size_type i = 0; i < d; ++i)
             {
                 char* chunk = reinterpret_cast<char*>(
-                    detail::aligned_alloc(ALIGNMENT, sizeof(value_type) * chunk_size)
-                );
+                    detail::aligned_alloc(ALIGNMENT, sizeof(value_type) * chunk_size));
                 if (chunk == NULL)
                     throw std::bad_alloc();
                 chunkList_.push_back(chunk);
@@ -425,8 +436,7 @@ class ChunkContainer
             if (chunk_ == chunkList_.size() - 1)
             {
                 char* chunk = reinterpret_cast<char*>(
-                detail::aligned_alloc(ALIGNMENT, sizeof(value_type) * chunk_size)
-                );
+                    detail::aligned_alloc(ALIGNMENT, sizeof(value_type) * chunk_size));
                 if (chunk == NULL)
                     throw std::bad_alloc();
                 chunkList_.push_back(chunk);

--- a/src/XAD/Complex.hpp
+++ b/src/XAD/Complex.hpp
@@ -49,7 +49,9 @@ class complex_impl
   public:
     typedef T value_type;
 
-    explicit complex_impl(const T& areal = T(), const T& aimag = T()) : real_(areal), imag_(aimag) {}
+    explicit complex_impl(const T& areal = T(), const T& aimag = T()) : real_(areal), imag_(aimag)
+    {
+    }
 
     template <class X>
     explicit complex_impl(const std::complex<X>& o) : real_(o.real()), imag_(o.imag())
@@ -212,7 +214,7 @@ class complex<xad::AReal<T>> : public complex<xad::ADTypeBase<T, xad::AReal<T>>>
     }
 
     template <class X>
-    XAD_INLINE complex(    // cppcheck-suppress noExplicitConstructor
+    XAD_INLINE complex(  // cppcheck-suppress noExplicitConstructor
         const X& areal,
         typename std::enable_if<xad::ExprTraits<X>::isExpr &&
                                 xad::ExprTraits<X>::direction == xad::DIR_REVERSE>::type* = nullptr)
@@ -239,21 +241,22 @@ class complex<xad::FReal<T>> : public complex<xad::ADTypeBase<T, xad::FReal<T>>>
 
     // inheriting template constructors doesn't work in all compilers
 
-    XAD_INLINE complex(const xad::FReal<T>& areal = xad::FReal<T>(),  // cppcheck-suppress noExplicitConstructor
-                       const xad::FReal<T>& aimag = xad::FReal<T>())
+    XAD_INLINE complex(
+        const xad::FReal<T>& areal = xad::FReal<T>(),  // cppcheck-suppress noExplicitConstructor
+        const xad::FReal<T>& aimag = xad::FReal<T>())
         : base(areal, aimag)
     {
     }
 
     template <class X>
-    XAD_INLINE complex(const X& areal,    // cppcheck-suppress noExplicitConstructor
+    XAD_INLINE complex(const X& areal,  // cppcheck-suppress noExplicitConstructor
                        typename std::enable_if<!xad::ExprTraits<X>::isExpr>::type* = nullptr)
         : base(xad::FReal<T>(areal), xad::FReal<T>())
     {
     }
 
     template <class X>
-    XAD_INLINE complex(   // cppcheck-suppress noExplicitConstructor
+    XAD_INLINE complex(  // cppcheck-suppress noExplicitConstructor
         const X& areal,
         typename std::enable_if<xad::ExprTraits<X>::isExpr &&
                                 xad::ExprTraits<X>::direction == xad::DIR_FORWARD>::type* = nullptr)
@@ -262,7 +265,9 @@ class complex<xad::FReal<T>> : public complex<xad::ADTypeBase<T, xad::FReal<T>>>
     }
 
     template <class X>
-    XAD_INLINE complex(const complex<X>& o) : base(xad::FReal<T>(o.real()), xad::FReal<T>(o.imag()))  // cppcheck-suppress noExplicitConstructor
+    XAD_INLINE complex(const complex<X>& o)
+        : base(xad::FReal<T>(o.real()),
+               xad::FReal<T>(o.imag()))  // cppcheck-suppress noExplicitConstructor
     {
     }
 
@@ -372,7 +377,8 @@ XAD_INLINE typename xad::ExprTraits<Derived>::value_type arg_impl(
 template <class T>
 XAD_INLINE T arg_impl(const std::complex<T>& z);
 
-#if (defined(_MSC_VER) && (_MSC_VER < 1920) || (defined(__GNUC__) && __GNUC__ < 7)) && !defined(__clang__)
+#if (defined(_MSC_VER) && (_MSC_VER < 1920) || (defined(__GNUC__) && __GNUC__ < 7)) &&             \
+    !defined(__clang__)
 template <class Scalar, class Derived>
 XAD_INLINE typename xad::ExprTraits<Derived>::value_type proj_impl(
     const xad::Expression<Scalar, Derived>& x);
@@ -1100,7 +1106,8 @@ XAD_INLINE complex<xad::FReal<T>> conj(const complex<xad::FReal<T>>& z)
     return ret;
 }
 
-#if ((defined(_MSC_VER) && (_MSC_VER < 1920)) || (defined(__GNUC__) && __GNUC__ < 7)) && !defined(__clang__)
+#if ((defined(_MSC_VER) && (_MSC_VER < 1920)) || (defined(__GNUC__) && __GNUC__ < 7)) &&           \
+    !defined(__clang__)
 template <class Scalar, class Derived>
 XAD_INLINE typename xad::ExprTraits<Derived>::value_type conj(
     const xad::Expression<Scalar, Derived>& x)
@@ -2283,7 +2290,8 @@ XAD_INLINE typename xad::ExprTraits<Derived>::value_type arg_impl(
 #endif
 }
 
-#if (defined(_MSC_VER) && (_MSC_VER < 1920) || (defined(__GNUC__) && __GNUC__ < 7)) && !defined(__clang__)
+#if (defined(_MSC_VER) && (_MSC_VER < 1920) || (defined(__GNUC__) && __GNUC__ < 7)) &&             \
+    !defined(__clang__)
 template <class Scalar, class Derived>
 XAD_INLINE typename xad::ExprTraits<Derived>::value_type proj_impl(
     const xad::Expression<Scalar, Derived>& x)

--- a/src/XAD/Expression.hpp
+++ b/src/XAD/Expression.hpp
@@ -44,16 +44,34 @@ struct Expression
 
 #ifdef XAD_ALLOW_INT_CONVERSION
     XAD_INLINE explicit operator char() const { return static_cast<char>(getValue()); }
-    XAD_INLINE explicit operator unsigned char() const { return static_cast<unsigned char>(getValue()); }
-    XAD_INLINE explicit operator signed char() const { return static_cast<signed char>(getValue()); }
+    XAD_INLINE explicit operator unsigned char() const
+    {
+        return static_cast<unsigned char>(getValue());
+    }
+    XAD_INLINE explicit operator signed char() const
+    {
+        return static_cast<signed char>(getValue());
+    }
     XAD_INLINE explicit operator short() const { return static_cast<short>(getValue()); }
-    XAD_INLINE explicit operator unsigned short() const { return static_cast<unsigned short>(getValue()); }
+    XAD_INLINE explicit operator unsigned short() const
+    {
+        return static_cast<unsigned short>(getValue());
+    }
     XAD_INLINE explicit operator int() const { return static_cast<int>(getValue()); }
-    XAD_INLINE explicit operator unsigned int() const { return static_cast<unsigned int>(getValue()); }
+    XAD_INLINE explicit operator unsigned int() const
+    {
+        return static_cast<unsigned int>(getValue());
+    }
     XAD_INLINE explicit operator long() const { return static_cast<long>(getValue()); }
-    XAD_INLINE explicit operator unsigned long() const { return static_cast<unsigned long>(getValue()); }
+    XAD_INLINE explicit operator unsigned long() const
+    {
+        return static_cast<unsigned long>(getValue());
+    }
     XAD_INLINE explicit operator long long() const { return static_cast<long long>(getValue()); }
-    XAD_INLINE explicit operator unsigned long long() const { return static_cast<unsigned long long>(getValue()); }
+    XAD_INLINE explicit operator unsigned long long() const
+    {
+        return static_cast<unsigned long long>(getValue());
+    }
 #endif
 
     // convert to boolean

--- a/src/XAD/Literals.hpp
+++ b/src/XAD/Literals.hpp
@@ -44,7 +44,8 @@ struct ADTypeBase : public Expression<Scalar, Derived>
     typedef typename ExprTraits<Derived>::value_type value_type;
     typedef typename ExprTraits<Derived>::nested_type nested_type;
 
-    static_assert(std::is_floating_point<nested_type>::value, "Active AD types only work with floating point");
+    static_assert(std::is_floating_point<nested_type>::value,
+                  "Active AD types only work with floating point");
 
     constexpr explicit XAD_INLINE ADTypeBase(Scalar val = Scalar()) : a_(val) {}
     constexpr XAD_INLINE ADTypeBase(ADTypeBase&& o) noexcept = default;
@@ -84,24 +85,32 @@ struct ADTypeBase : public Expression<Scalar, Derived>
         return derived();
     }
     template <class I>
-    XAD_INLINE typename std::enable_if<std::is_integral<I>::value, Derived>::type& 
-    operator+=(I x) { return *this += Scalar(x); }
+    XAD_INLINE typename std::enable_if<std::is_integral<I>::value, Derived>::type& operator+=(I x)
+    {
+        return *this += Scalar(x);
+    }
     XAD_INLINE Derived& operator-=(Scalar rhs)
     {
         a_ -= rhs;
         return derived();
     }
     template <class I>
-    XAD_INLINE typename std::enable_if<std::is_integral<I>::value, Derived>::type& 
-    operator-=(I x) { return *this -= Scalar(x); }
+    XAD_INLINE typename std::enable_if<std::is_integral<I>::value, Derived>::type& operator-=(I x)
+    {
+        return *this -= Scalar(x);
+    }
     XAD_INLINE Derived& operator*=(Scalar x) { return derived() = (derived() * x); }
     template <class I>
-    XAD_INLINE typename std::enable_if<std::is_integral<I>::value, Derived>::type& 
-    operator*=(I x) { return *this *= Scalar(x); }
+    XAD_INLINE typename std::enable_if<std::is_integral<I>::value, Derived>::type& operator*=(I x)
+    {
+        return *this *= Scalar(x);
+    }
     XAD_INLINE Derived& operator/=(Scalar x) { return derived() = (derived() / x); }
     template <class I>
-    XAD_INLINE typename std::enable_if<std::is_integral<I>::value, Derived>::type& 
-    operator/=(I x) { return *this /= Scalar(x); }
+    XAD_INLINE typename std::enable_if<std::is_integral<I>::value, Derived>::type& operator/=(I x)
+    {
+        return *this /= Scalar(x);
+    }
     XAD_INLINE Derived& operator+=(const value_type& x) { return derived() = derived() + x; }
     XAD_INLINE Derived& operator-=(const value_type& x) { return derived() = derived() - x; }
     XAD_INLINE Derived& operator*=(const value_type& x) { return derived() = derived() * x; }
@@ -163,9 +172,7 @@ struct AReal : public ADTypeBase<Scalar, AReal<Scalar>>
     typedef Scalar value_type;
     typedef typename ExprTraits<Scalar>::nested_type nested_type;
 
-    XAD_INLINE AReal(nested_type val = nested_type()) : base_type(val), slot_(INVALID_SLOT)
-    {
-    }
+    XAD_INLINE AReal(nested_type val = nested_type()) : base_type(val), slot_(INVALID_SLOT) {}
 
     // explicit conversion from int (also used by static_cast) to avoid warnings
     template <class U>
@@ -222,7 +229,8 @@ struct AReal : public ADTypeBase<Scalar, AReal<Scalar>>
     }
 
     template <class Expr>
-    XAD_INLINE AReal(const Expression<Scalar, Expr>& expr);  // cppcheck-suppress noExplicitConstructor
+    XAD_INLINE AReal(
+        const Expression<Scalar, Expr>& expr);  // cppcheck-suppress noExplicitConstructor
 
     template <class Expr>
     XAD_INLINE AReal& operator=(const Expression<Scalar, Expr>& expr);
@@ -416,7 +424,8 @@ struct FReal : public ADTypeBase<Scalar, FReal<Scalar>>
 
     // explicit conversion from int (also used by static_cast) to avoid warnings
     template <class U>
-    constexpr XAD_INLINE explicit FReal(U val, typename std::enable_if<std::is_integral<U>::value>::type* = 0)
+    constexpr XAD_INLINE explicit FReal(
+        U val, typename std::enable_if<std::is_integral<U>::value>::type* = 0)
         : base_type(static_cast<nested_type>(val)), der_()
     {
     }
@@ -434,7 +443,8 @@ struct FReal : public ADTypeBase<Scalar, FReal<Scalar>>
     }
 
     template <class Expr>
-    XAD_INLINE FReal(const Expression<Scalar, Expr>& expr);    // cppcheck-suppress noExplicitConstructor
+    XAD_INLINE FReal(
+        const Expression<Scalar, Expr>& expr);  // cppcheck-suppress noExplicitConstructor
     template <class Expr>
     XAD_INLINE FReal& operator=(const Expression<Scalar, Expr>& expr);
 

--- a/src/XAD/Macros.hpp
+++ b/src/XAD/Macros.hpp
@@ -56,9 +56,8 @@ void ignore_unused_variable(const T&)
 #else
 // we can't use thread_local here, as MacOS has an issue with that
 #ifdef _WIN32
-#  define XAD_THREAD_LOCAL __declspec(thread)
-#else 
-#  define XAD_THREAD_LOCAL __thread
+#define XAD_THREAD_LOCAL __declspec(thread)
+#else
+#define XAD_THREAD_LOCAL __thread
 #endif
 #endif
-

--- a/src/XAD/MathFunctions.hpp
+++ b/src/XAD/MathFunctions.hpp
@@ -104,11 +104,9 @@ XAD_INLINE float smooth_min(float x, float y, float c = 0.001f)
     return 0.5f * (x + y - smooth_abs(x - y, c));
 }
 
-
-using ::std::atan2;
-using ::std::fmod;
 using ::std::acosh;
 using ::std::asinh;
+using ::std::atan2;
 using ::std::atanh;
 using ::std::cbrt;
 using ::std::erf;
@@ -117,6 +115,7 @@ using ::std::exp2;
 using ::std::expm1;
 using ::std::fmax;
 using ::std::fmin;
+using ::std::fmod;
 using ::std::fpclassify;
 using ::std::isfinite;
 using ::std::isinf;
@@ -124,10 +123,10 @@ using ::std::isnan;
 using ::std::isnormal;
 using ::std::log1p;
 using ::std::log2;
+using ::std::nextafter;
 using ::std::remainder;
 using ::std::round;
 using ::std::signbit;
 using ::std::trunc;
-using ::std::nextafter;
 
 }  // namespace xad

--- a/src/XAD/ReusableRange.hpp
+++ b/src/XAD/ReusableRange.hpp
@@ -115,7 +115,8 @@ inline bool operator==(const ReusableRange<T>& a, const ReusableRange<T>& b)
 }
 
 template <class C, class Traits, class T>
-inline std::basic_ostream<C, Traits>& operator<<(std::basic_ostream<C, Traits>& os, const ReusableRange<T>& r)
+inline std::basic_ostream<C, Traits>& operator<<(std::basic_ostream<C, Traits>& os,
+                                                 const ReusableRange<T>& r)
 {
     return os << "[" << r.first() << ", " << r.second() << ")";
 }

--- a/src/XAD/StdCompatibility.hpp
+++ b/src/XAD/StdCompatibility.hpp
@@ -25,14 +25,14 @@ expressions to work, as well as specialising numeric_limits.
 
 #pragma once
 
+#include <XAD/BinaryOperators.hpp>
 #include <XAD/Literals.hpp>
 #include <XAD/MathFunctions.hpp>
 #include <XAD/UnaryOperators.hpp>
-#include <XAD/BinaryOperators.hpp>
 #include <cmath>
+#include <functional>
 #include <limits>
 #include <string>
-#include <functional>
 #include <type_traits>
 
 namespace std
@@ -47,6 +47,7 @@ using xad::atan2;
 using xad::atanh;
 using xad::cbrt;
 using xad::ceil;
+using xad::copysign;
 using xad::cos;
 using xad::cosh;
 using xad::erf;
@@ -61,6 +62,7 @@ using xad::fmin;
 using xad::fmod;
 using xad::fpclassify;
 using xad::frexp;
+using xad::ilogb;
 using xad::isfinite;
 using xad::isinf;
 using xad::isnan;
@@ -75,10 +77,12 @@ using xad::lround;
 using xad::max;
 using xad::min;
 using xad::modf;
+using xad::nextafter;
 using xad::pow;
 using xad::remainder;
 using xad::remquo;
 using xad::round;
+using xad::scalbn;
 using xad::signbit;
 using xad::sin;
 using xad::sinh;
@@ -86,10 +90,6 @@ using xad::sqrt;
 using xad::tan;
 using xad::tanh;
 using xad::trunc;
-using xad::nextafter;
-using xad::ilogb;
-using xad::scalbn;
-using xad::copysign;
 
 template <class Scalar, class Derived>
 inline std::string to_string(const xad::Expression<Scalar, Derived>& _Val)
@@ -99,8 +99,6 @@ inline std::string to_string(const xad::Expression<Scalar, Derived>& _Val)
 
 }  // namespace std
 
-
-
 namespace std
 {
 
@@ -109,8 +107,8 @@ namespace std
 // for the majority of cases
 
 template <class T>
-struct numeric_limits<xad::AReal<T>> : std::numeric_limits<T> 
-{ 
+struct numeric_limits<xad::AReal<T>> : std::numeric_limits<T>
+{
 };
 
 template <class T>
@@ -119,7 +117,6 @@ struct numeric_limits<xad::FReal<T>> : std::numeric_limits<T>
 };
 
 }  // namespace std
-
 
 // hashing for active types
 namespace std
@@ -220,8 +217,8 @@ constexpr bool _Is_any_of_v<xad::FReal<T>, float, double, long double> =
 #else
 }
 #include <random>
-namespace std {
-
+namespace std
+{
 
 // prior versions of MSVC (2015) use a different check
 template <class T>
@@ -239,4 +236,3 @@ struct _Is_RealType<xad::FReal<T>> : public _Is_RealType<T>
 #endif
 
 }  // namespace std
-

--- a/src/XAD/Tape.hpp
+++ b/src/XAD/Tape.hpp
@@ -27,12 +27,12 @@
 #include <XAD/Config.hpp>
 #include <XAD/Exceptions.hpp>
 #include <XAD/Macros.hpp>
-#include <XAD/TapeContainer.hpp>
 #include <XAD/ReusableRange.hpp>
-#include <type_traits>
-#include <list>
+#include <XAD/TapeContainer.hpp>
 #include <complex>
+#include <list>
 #include <stack>
+#include <type_traits>
 #include <vector>
 
 namespace xad
@@ -104,10 +104,7 @@ class Tape
             active_tape_ = nullptr;
     }
     XAD_INLINE bool isActive() const { return active_tape_ == this; }
-    XAD_INLINE static Tape* getActive()
-    {
-        return active_tape_;
-    }
+    XAD_INLINE static Tape* getActive() { return active_tape_; }
 
     XAD_INLINE void registerInput(active_type& inp)
     {
@@ -124,9 +121,11 @@ class Tape
         registerInput(reim_ptr[0]);
         registerInput(reim_ptr[1]);
     }
-    
-    XAD_INLINE void registerOutput(active_type& outp) {
-        if (!outp.shouldRecord()) {
+
+    XAD_INLINE void registerOutput(active_type& outp)
+    {
+        if (!outp.shouldRecord())
+        {
             outp.slot_ = registerVariable();
             pushLhs(outp.slot_);
         }
@@ -198,7 +197,7 @@ class Tape
 
     // internal tape recording
     slot_type registerVariable()
-    { 
+    {
         ++currentRec_->numDerivatives_;
 #ifdef XAD_TAPE_REUSE_SLOTS
         return registerVariableReuseSlots();
@@ -221,7 +220,7 @@ class Tape
     void pushRhs(Real&& multiplier, slot_type slot);
     void pushLhs(slot_type slot);
     void pushAll(slot_type lhs, Real* multipliers, slot_type* slots, unsigned n);
-    
+
     // capacity
     size_type getNumVariables() const;
     size_type getNumOperations() const;

--- a/src/XAD/UnaryExpr.hpp
+++ b/src/XAD/UnaryExpr.hpp
@@ -28,7 +28,6 @@
 #include <XAD/Macros.hpp>
 #include <XAD/Traits.hpp>
 
-
 namespace xad
 {
 namespace detail
@@ -63,7 +62,9 @@ struct UnaryExpr : Expression<Scalar, UnaryExpr<Scalar, Op, Expr> >
 {
     typedef detail::UnaryDerivativeImpl<OperatorTraits<Op>::useResultBasedDerivatives == 1>
         der_impl;
-    XAD_INLINE explicit UnaryExpr(const Expr& a, Op op = Op()) : a_(a), op_(op), v_(op_(a_.value())) {}
+    XAD_INLINE explicit UnaryExpr(const Expr& a, Op op = Op()) : a_(a), op_(op), v_(op_(a_.value()))
+    {
+    }
     XAD_INLINE Scalar value() const { return v_; }
     template <class Tape>
     XAD_INLINE void calc_derivatives(Tape& s, const Scalar& mul) const

--- a/src/XAD/UnaryMathFunctors.hpp
+++ b/src/XAD/UnaryMathFunctors.hpp
@@ -29,7 +29,6 @@
 #include <XAD/UnaryFunctors.hpp>
 #include <type_traits>
 
-
 namespace xad
 {
 // degrees and radians are mapped to products
@@ -55,7 +54,10 @@ struct radians_op : scalar_prod_op<Scalar, Scalar>
     template <class Scalar>                                                                        \
     struct func##_op                                                                               \
     {                                                                                              \
-        XAD_INLINE Scalar operator()(const Scalar& a) const { return func(a); }                    \
+        XAD_INLINE Scalar operator()(const Scalar& a) const                                        \
+        {                                                                                          \
+            return func(a);                                                                        \
+        }                                                                                          \
         XAD_INLINE Scalar derivative(const Scalar& a) const                                        \
         {                                                                                          \
             XAD_UNUSED_VARIABLE(a);                                                                \
@@ -93,7 +95,10 @@ XAD_MAKE_UNARY_FUNCTOR(round, Scalar())
     template <class Scalar>                                                                        \
     struct func##_op                                                                               \
     {                                                                                              \
-        XAD_INLINE Scalar operator()(const Scalar& a) const { return func(a); }                    \
+        XAD_INLINE Scalar operator()(const Scalar& a) const                                        \
+        {                                                                                          \
+            return func(a);                                                                        \
+        }                                                                                          \
         XAD_INLINE Scalar derivative(const Scalar& a, const Scalar& v) const                       \
         {                                                                                          \
             XAD_UNUSED_VARIABLE(a);                                                                \
@@ -136,8 +141,13 @@ struct fabs_op : abs_op<Scalar>
     template <class Scalar, class T2>                                                              \
     struct scalar_##func##2_op                                                                     \
     {                                                                                              \
-        XAD_INLINE explicit scalar_##func##2_op(const T2& b_t) : b(b_t) {}                         \
-        XAD_INLINE Scalar operator()(const Scalar& a) const { return func(a, b); }                 \
+        XAD_INLINE explicit scalar_##func##2_op(const T2& b_t) : b(b_t)                            \
+        {                                                                                          \
+        }                                                                                          \
+        XAD_INLINE Scalar operator()(const Scalar& a) const                                        \
+        {                                                                                          \
+            return func(a, b);                                                                     \
+        }                                                                                          \
         XAD_INLINE Scalar derivative(const Scalar& a, const Scalar& v) const                       \
         {                                                                                          \
             XAD_UNUSED_VARIABLE(a);                                                                \
@@ -149,8 +159,13 @@ struct fabs_op : abs_op<Scalar>
     template <class Scalar, class T2>                                                              \
     struct scalar_##func##1_op                                                                     \
     {                                                                                              \
-        XAD_INLINE explicit scalar_##func##1_op(const T2& b_t) : b(b_t) {}                         \
-        XAD_INLINE Scalar operator()(const Scalar& a) const { return func(b, a); }                 \
+        XAD_INLINE explicit scalar_##func##1_op(const T2& b_t) : b(b_t)                            \
+        {                                                                                          \
+        }                                                                                          \
+        XAD_INLINE Scalar operator()(const Scalar& a) const                                        \
+        {                                                                                          \
+            return func(b, a);                                                                     \
+        }                                                                                          \
         XAD_INLINE Scalar derivative(const Scalar& a, const Scalar& v) const                       \
         {                                                                                          \
             XAD_UNUSED_VARIABLE(a);                                                                \
@@ -397,7 +412,11 @@ template <class Scalar, class T2>
 struct scalar_remquo2_op
 {
     XAD_INLINE scalar_remquo2_op(const T2& b, int* quo) : b_(b), quo_(quo) {}
-    XAD_INLINE Scalar operator()(const Scalar& a) const { using std::remquo; return remquo(a, b_, quo_); }
+    XAD_INLINE Scalar operator()(const Scalar& a) const
+    {
+        using std::remquo;
+        return remquo(a, b_, quo_);
+    }
     XAD_INLINE Scalar derivative(const Scalar&) const { return Scalar(1); }
     T2 b_;
     int* quo_;

--- a/src/XAD/UnaryOperators.hpp
+++ b/src/XAD/UnaryOperators.hpp
@@ -476,14 +476,14 @@ XAD_INLINE typename ExprTraits<Derived>::value_type copysign(const Expression<Sc
 }
 
 template <class Scalar, class Derived>
-XAD_INLINE double copysign(double x, const Expression<Scalar, Derived>& y) 
+XAD_INLINE double copysign(double x, const Expression<Scalar, Derived>& y)
 {
     using std::copysign;
     return copysign(x, value(y));
 }
 
 template <class Scalar, class Derived>
-XAD_INLINE float copysign(float x, const Expression<Scalar, Derived>& y) 
+XAD_INLINE float copysign(float x, const Expression<Scalar, Derived>& y)
 {
     using std::copysign;
     return copysign(x, value(y));

--- a/src/XAD/XAD.hpp
+++ b/src/XAD/XAD.hpp
@@ -31,8 +31,8 @@
 #include <XAD/BinaryOperators.hpp>
 #include <XAD/CheckpointCallback.hpp>
 #include <XAD/ChunkContainer.hpp>
-#include <XAD/Config.hpp>
 #include <XAD/Complex.hpp>
+#include <XAD/Config.hpp>
 #include <XAD/Exceptions.hpp>
 #include <XAD/Expression.hpp>
 #include <XAD/Interface.hpp>
@@ -46,4 +46,3 @@
 #include <XAD/UnaryMathFunctors.hpp>
 #include <XAD/UnaryOperators.hpp>
 #include <XAD/Version.hpp>
-

--- a/test/Checkpointing_test.cpp
+++ b/test/Checkpointing_test.cpp
@@ -25,7 +25,6 @@
 #include <XAD/XAD.hpp>
 #include <gtest/gtest.h>
 
-
 template <class T>
 void g(int n, T& x)
 {
@@ -54,7 +53,7 @@ class GCheckpointCallback : public xad::CheckpointCallback<Tape>
         idx_type outputidx = idx_.top();
         idx_.pop();
         idx_type inputidx = idx_.top();
-        idx_.pop();  
+        idx_.pop();
         int n = n_.top();
         n_.pop();
         int c = int(x_.size());
@@ -205,7 +204,7 @@ TEST(Checkpointing, equidistantLoop)
     EXPECT_LT(memchkpt, memstraight);
 }
 
-//#define VERBOSE 1
+// #define VERBOSE 1
 #define STATISTICS 1
 
 size_t max_tape_size = 0;
@@ -358,9 +357,9 @@ void g_rec_insert_checkpoint(int from, int to, int stride, T& x, RUN_MODE m)
         if (to - from > stride)
         {
             g_rec_insert_checkpoint(from, from + (to - from) / 2, stride, x,
-                           CHECKPOINT_ARGUMENTS_AND_RUN_PASSIVELY);
+                                    CHECKPOINT_ARGUMENTS_AND_RUN_PASSIVELY);
             g_rec_insert_checkpoint(from + (to - from) / 2, to, stride, x,
-                           CHECKPOINT_ARGUMENTS_AND_RUN_PASSIVELY);
+                                    CHECKPOINT_ARGUMENTS_AND_RUN_PASSIVELY);
         }
         else
         {

--- a/test/ChunkContainer_test.cpp
+++ b/test/ChunkContainer_test.cpp
@@ -23,8 +23,8 @@
 ******************************************************************************/
 
 #include <XAD/ChunkContainer.hpp>
-#include <gtest/gtest.h>
 #include <gmock/gmock.h>
+#include <gtest/gtest.h>
 
 using namespace ::testing;
 using xad::ChunkContainer;
@@ -78,7 +78,7 @@ TEST(ChunkContainer, uninitialized_extend)
     auto it = chk.iterator_at(i);
     for (std::size_t j = i + 10; i < j; ++i)
     {
-        ::new(&*it++) int(static_cast<int>(i));
+        ::new (&*it++) int(static_cast<int>(i));
     }
 
     for (std::size_t j = 0; j < ChunkContainer<int>::chunk_size - 4 + 10; ++j)
@@ -118,11 +118,9 @@ TEST(ChunkContainer, move_assign)
 TEST(ChunkContainer, multichunk)
 {
     ChunkContainer<int, 8> chk;
-    for (int i = 0; i < 20; ++i)
-        chk.push_back(i);
+    for (int i = 0; i < 20; ++i) chk.push_back(i);
 
-    for (int i = 0; i < 20; ++i)
-        EXPECT_THAT(chk[size_t(i)], Eq(i)) << "at " << i;
+    for (int i = 0; i < 20; ++i) EXPECT_THAT(chk[size_t(i)], Eq(i)) << "at " << i;
 }
 
 namespace
@@ -133,10 +131,7 @@ struct NonPodTester
     NonPodTester(const NonPodTester&) { ++copies; }
     NonPodTester(NonPodTester&&) = delete;
 
-    ~NonPodTester()
-    {
-        ++destructions;
-    }
+    ~NonPodTester() { ++destructions; }
 
     static void reset()
     {
@@ -153,7 +148,7 @@ struct NonPodTester
 int NonPodTester::constructions = 0;
 int NonPodTester::destructions = 0;
 int NonPodTester::copies = 0;
-}
+}  // namespace
 
 TEST(ChunkContainer, non_pod_type)
 {
@@ -166,14 +161,12 @@ TEST(ChunkContainer, non_pod_type)
         EXPECT_THAT(NonPodTester::copies, Eq(20));
     }
     EXPECT_THAT(NonPodTester::copies + NonPodTester::constructions, Eq(NonPodTester::destructions));
-    
 }
 
 TEST(ChunkContainer, resize)
 {
     ChunkContainer<int, 8> chk;
-    for (int i = 0; i < 10; ++i)
-        chk.push_back(i);
+    for (int i = 0; i < 10; ++i) chk.push_back(i);
 
     EXPECT_THAT(chk.size(), Eq(10u));
 
@@ -181,8 +174,7 @@ TEST(ChunkContainer, resize)
     EXPECT_THAT(chk.size(), Eq(15u));
     chk[12] = 12;
 
-    for (int i = 0; i < 10; ++i)
-        EXPECT_THAT(chk[size_t(i)], Eq(i));
+    for (int i = 0; i < 10; ++i) EXPECT_THAT(chk[size_t(i)], Eq(i));
     for (int i = 10; i < 15; ++i)
     {
         if (i == 12)
@@ -195,8 +187,7 @@ TEST(ChunkContainer, resize)
 TEST(ChunkContainer, append)
 {
     ChunkContainer<int, 8> chk;
-    for (int i = 0; i < 14; ++i)
-        chk.push_back(i);
+    for (int i = 0; i < 14; ++i) chk.push_back(i);
 
     std::vector<int> newvals = {14, 15, 16, 17};
     // note: we can only append sizes less than chunk size (8)
@@ -204,6 +195,5 @@ TEST(ChunkContainer, append)
 
     EXPECT_THAT(chk.size(), Eq(18u));
 
-    for (int i = 0; i < 18; ++i)
-        EXPECT_THAT(chk[size_t(i)], Eq(i)) << "at " << i;
+    for (int i = 0; i < 18; ++i) EXPECT_THAT(chk[size_t(i)], Eq(i)) << "at " << i;
 }

--- a/test/Complex_test.cpp
+++ b/test/Complex_test.cpp
@@ -91,7 +91,8 @@ MATCHER(IsNegativeInf, "")
     return xad::isinf(arg) && arg < 0.0;
 }
 
-#if (defined(__GNUC__) && __GNUC__ < 5) && !defined(__clang__)  // with gcc 4, we're using gtest 1.10, which doesn't have IsNan
+#if (defined(__GNUC__) && __GNUC__ < 5) &&                                                         \
+    !defined(__clang__)  // with gcc 4, we're using gtest 1.10, which doesn't have IsNan
 MATCHER(IsNan, "")
 {
     (void)result_listener;  // silence warning
@@ -1451,7 +1452,8 @@ TYPED_TEST(ComplexTest, ProjOfDoubleOrInteger)
     EXPECT_THAT(std::imag(std::proj(z)), DoubleNear(0.0, 1e-9));
     EXPECT_THAT(std::real(std::proj(z1)), IsPositiveInf());
     EXPECT_THAT(std::imag(std::proj(z1)), IsPositiveZero());
-#if ((defined(_MSC_VER) && _MSC_VER < 1920) || (defined(__GNUC__) && __GNUC__ < 7)) && !defined(__clang__)
+#if ((defined(_MSC_VER) && _MSC_VER < 1920) || (defined(__GNUC__) && __GNUC__ < 7)) &&             \
+    !defined(__clang__)
     // VS 2017 evaluates this differently
     EXPECT_THAT(std::real(std::proj(z1n)), IsNegativeInf());
 #else
@@ -1473,7 +1475,8 @@ TYPED_TEST(ComplexTest, ProjOfFloat)
     EXPECT_THAT(double(std::imag(std::proj(z))), DoubleNear(0.0, 1e-6));
     EXPECT_THAT(double(std::real(std::proj(z1))), IsPositiveInf());
     EXPECT_THAT(double(std::imag(std::proj(z1))), IsPositiveZero());
-#if ((defined(_MSC_VER) && _MSC_VER < 1920) || (defined(__GNUC__) && __GNUC__ < 7)) && !defined(__clang__)
+#if ((defined(_MSC_VER) && _MSC_VER < 1920) || (defined(__GNUC__) && __GNUC__ < 7)) &&             \
+    !defined(__clang__)
     // VS 2017 evaluates this differently
     EXPECT_THAT(double(std::real(std::proj(z1n))), IsNegativeInf());
 #else
@@ -1495,7 +1498,8 @@ TYPED_TEST(ComplexTest, ProjOfScalar)
     EXPECT_THAT(xad::value(std::imag(std::proj(z))), DoubleNear(0.0, 1e-9));
     EXPECT_THAT(xad::value(std::real(std::proj(z1))), IsPositiveInf());
     EXPECT_THAT(xad::value(std::imag(std::proj(z1))), IsPositiveZero());
-#if ((defined(_MSC_VER) && _MSC_VER < 1920) || (defined(__GNUC__) && __GNUC__ < 7)) && !defined(__clang__)
+#if ((defined(_MSC_VER) && _MSC_VER < 1920) || (defined(__GNUC__) && __GNUC__ < 7)) &&             \
+    !defined(__clang__)
     // VS 2017 evaluates this differently
     EXPECT_THAT(xad::value(std::real(std::proj(z1n))), IsNegativeInf());
 #else

--- a/test/Exceptions_test.cpp
+++ b/test/Exceptions_test.cpp
@@ -56,7 +56,6 @@ TEST(Exceptions, popCallback)
     EXPECT_THROW(t.popCallback(), xad::OutOfRange);
 }
 
-
 TEST(Exceptions, getDerivatives)
 {
     xad::Tape<double> t;
@@ -81,4 +80,3 @@ TEST(Exceptions, checkpoints)
     EXPECT_NO_THROW(t.incrementAdjoint(x.getSlot(), 1.0));
     EXPECT_THROW(t.incrementAdjoint(12312, 1.0), xad::OutOfRange);
 }
-

--- a/test/ExpressionMath3_test.cpp
+++ b/test/ExpressionMath3_test.cpp
@@ -594,7 +594,6 @@ TEST(ExpressionsMath, modfExprScalar)
     EXPECT_NEAR(testFunctor_modfExprScalar::ipart, 1.0, 1e-9);
 }
 
-
 struct testFunctor_copysignScalar1
 {
     explicit testFunctor_copysignScalar1(double op1) : op1_(op1) {}

--- a/test/ExpressionMeta_test.cpp
+++ b/test/ExpressionMeta_test.cpp
@@ -256,7 +256,7 @@ TEST(ExpressionMeta, reverseExprTraits)
 {
     xad::AReal<double> x = 1., y = 1.;
     auto binx = x * x;
-    auto binx2 = binx + 2. * y;   // cppcheck-suppress unreadVariable
+    auto binx2 = binx + 2. * y;  // cppcheck-suppress unreadVariable
     typedef decltype(binx2) type;
 
     static_assert(xad::ExprTraits<type>::isExpr, "should be an expression");
@@ -268,7 +268,8 @@ TEST(ExpressionMeta, reverseExprTraits)
                   "should be reverse");
 }
 
-TEST(ExpressionMeta, LongExpression) {
+TEST(ExpressionMeta, LongExpression)
+{
     using complex_expr = xad::BinaryExpr<
         double, xad::prod_op<double>,
         xad::UnaryExpr<double, xad::scalar_prod_op<double, double>, xad::ADVar<double>>,
@@ -285,5 +286,4 @@ TEST(ExpressionMeta, LongExpression) {
     static_assert(xad::ExprTraits<complex_expr>::numVariables == 3, "should be 3 variables");
     static_assert(xad::ExprTraits<complex_expr>::direction == xad::Direction::DIR_REVERSE,
                   "should be reverse");
-    
 }

--- a/test/ExpressionsConversion_test.cpp
+++ b/test/ExpressionsConversion_test.cpp
@@ -25,8 +25,8 @@
 ******************************************************************************/
 
 #include <XAD/XAD.hpp>
-#include <gtest/gtest.h>
 #include <gmock/gmock.h>
+#include <gtest/gtest.h>
 
 using namespace ::testing;
 
@@ -332,9 +332,9 @@ typedef ::testing::Types<char, unsigned char, signed char, short, unsigned short
 TYPED_TEST_SUITE(ExpressionsIntConversion, int_test_types);
 
 TYPED_TEST(ExpressionsIntConversion, canConvertARealToIntegers)
-{ 
+{
     xad::AReal<double> x = 42.0;
-    
+
     TypeParam i = static_cast<TypeParam>(x);
     TypeParam j = (TypeParam)x;
     TypeParam k = TypeParam(x);
@@ -358,9 +358,9 @@ TYPED_TEST(ExpressionsIntConversion, canConvertFRealToIntegers)
 }
 
 TYPED_TEST(ExpressionsIntConversion, canConvertARealExprToIntegers)
-{ 
+{
     xad::AReal<double> x = 42.0;
-    
+
     TypeParam i = static_cast<TypeParam>(floor(x));
     TypeParam j = (TypeParam)floor(x);
     TypeParam k = TypeParam(floor(x));

--- a/test/Expressions_test.cpp
+++ b/test/Expressions_test.cpp
@@ -60,7 +60,7 @@ TEST(Expressions, basic)
     EXPECT_DOUBLE_EQ(10.4, big.getValue());
 
     xad::AD res = big;  // construct from expression - puts it on tape
-    
+
     s.registerOutput(res);
     derivative(res) = 1.0;
     s.computeAdjoints();
@@ -95,7 +95,7 @@ TEST(Expressions, basic_fwd)
 
 TEST(Expressions, basic_fwd_fwd)
 {
-    typedef xad::FReal<xad::FReal<double> > AD;
+    typedef xad::FReal<xad::FReal<double>> AD;
 
     AD x = 1.0;
     derivative(value(x)) = 1.0;
@@ -109,10 +109,10 @@ TEST(Expressions, basic_fwd_fwd)
 
 TEST(Expressions, basic_adj_adj)
 {
-    typedef xad::AReal<xad::AReal<double> > AD;
+    typedef xad::AReal<xad::AReal<double>> AD;
 
     xad::Tape<double> si;
-    xad::Tape<xad::AReal<double> > so;
+    xad::Tape<xad::AReal<double>> so;
 
     AD x = 1.0;
     so.registerInput(x);
@@ -121,7 +121,7 @@ TEST(Expressions, basic_adj_adj)
     si.newRecording();
     AD res = sin(x);
     so.registerOutput(res);
-    
+
     value(derivative(res)) = 1.0;
     /*
     std::cout << "slot of x: " << x.getSlot() << "\n";
@@ -162,9 +162,9 @@ TEST(Expressions, basic_adj_adj)
 
 TEST(Expressions, basic_fwd_adj)
 {
-    typedef xad::AReal<xad::FReal<double> > AD;
+    typedef xad::AReal<xad::FReal<double>> AD;
 
-    xad::Tape<xad::FReal<double> > so;
+    xad::Tape<xad::FReal<double>> so;
 
     AD x = 1.0;
     derivative(value(x)) = 1.0;
@@ -195,7 +195,7 @@ TEST(Expressions, basic_fwd_adj)
 
 TEST(Expressions, basic_adj_fwd)
 {
-    typedef xad::FReal<xad::AReal<double> > AD;
+    typedef xad::FReal<xad::AReal<double>> AD;
 
     xad::Tape<double> si;
 
@@ -236,20 +236,20 @@ TEST(Expressions, wrapsAReal)
 
     static_assert((std::is_same<decltype(x1 + x2),
                                 xad::BinaryExpr<double, xad::add_op<double>, xad::ADVar<double>,
-                                                xad::ADVar<double> > >::value),
+                                                xad::ADVar<double>>>::value),
                   "ad type not wrapped");
     static_assert(
         (std::is_same<
             decltype(x1 + x2 + x1 * x2),
             xad::BinaryExpr<double, xad::add_op<double>,
                             xad::BinaryExpr<double, xad::add_op<double>, xad::ADVar<double>,
-                                            xad::ADVar<double> >,
+                                            xad::ADVar<double>>,
                             xad::BinaryExpr<double, xad::prod_op<double>, xad::ADVar<double>,
-                                            xad::ADVar<double> > > >::value),
+                                            xad::ADVar<double>>>>::value),
         "ad type not wrapped");
     static_assert((std::is_same<decltype(max(x1, x1)),
                                 xad::BinaryExpr<double, xad::max_op<double>, xad::ADVar<double>,
-                                                xad::ADVar<double> > >::value),
+                                                xad::ADVar<double>>>::value),
                   "AD type not wrapped");
 }
 
@@ -1528,7 +1528,8 @@ TEST(Expressions, canDeriveLongExpressionFromLambdaReturnAdjoint)
 {
     std::vector<xad::AD> tmp(3, 1.0);
     tmp[2] = 0.0;
-    auto lbd = [&](xad::AD in) -> xad::AD {
+    auto lbd = [&](xad::AD in) -> xad::AD
+    {
         // we make this function really long with loads of temporaries in the expression
         // to trigger problems with overwriting temp refs
         return tmp[0] * (xad::AD(in * in) * xad::AD(tmp[1]) + exp(in)) +
@@ -1559,7 +1560,8 @@ TEST(Expressions, canDeriveLongExpressionFromLambdaReturnForward)
 {
     std::vector<xad::FAD> tmp(3, 1.0);
     tmp[2] = 0.0;
-    auto lbd = [&](xad::FAD in) -> xad::FAD {
+    auto lbd = [&](xad::FAD in) -> xad::FAD
+    {
         // we make this function really long with loads of temporaries in the
         // expression to trigger problems with overwriting temp refs
         return tmp[0] * (xad::FAD(in * in) * xad::FAD(tmp[1]) + exp(in)) +
@@ -1749,8 +1751,8 @@ class ConstexprTest
         z = z - b3_;
         z = z / b4_;
 
-        using std::min;
         using std::max;
+        using std::min;
 
         z = min(z, a1_);
         z = max(z, a2_);
@@ -1762,7 +1764,8 @@ class ConstexprTest
         z = max<xad::AReal<double>>(z, c3_);
         z = max<xad::AReal<double>>(c4_, z);
 
-        if (z >= c1_ || (z < d3_ && !(z == d4_))) {
+        if (z >= c1_ || (z < d3_ && !(z == d4_)))
+        {
             z = min<xad::AReal<double>>(z, d1_);
             z = min<xad::AReal<double>>(d2_, z);
             z = max<xad::AReal<double>>(z, d3_);

--- a/test/HigherOrder_test.cpp
+++ b/test/HigherOrder_test.cpp
@@ -63,7 +63,7 @@ void driver_fwd_adj(const vector<double>& xv, const vector<double>& xt2, vector<
 
     f(x, y);
 
-    for (std::size_t i = 0; i < m; i++) tape.registerOutput(y[i]);   
+    for (std::size_t i = 0; i < m; i++) tape.registerOutput(y[i]);
     for (std::size_t i = 0; i < n; i++)
     {
         value(derivative(x[i])) = xa1[i];

--- a/test/PartialRollback_test.cpp
+++ b/test/PartialRollback_test.cpp
@@ -64,8 +64,7 @@ T evaluate(U path, const T& val)
     // derivative = 2 * val * path + std:exp(val);
 }
 
-}
-
+}  // namespace
 
 TEST(PartialRollback, MultiDerivativesInComplexLoop)
 {
@@ -108,25 +107,25 @@ TEST(PartialRollback, MultiDerivativesInNestedLoop)
     tape.newRecording();
 
     auto sim_position = tape.getPosition();
-    for (int p = 0; p < 5; ++p)  
+    for (int p = 0; p < 5; ++p)
     {
         tape.resetTo(sim_position);
-        for (int t = 0; t < 5; ++t) 
+        for (int t = 0; t < 5; ++t)
         {
             // value
-            xad::AD rpt = q * p * std::exp(-r * double(t));  
+            xad::AD rpt = q * p * std::exp(-r * double(t));
             // partial derivatives manual
             double drpt_dq = double(p) * std::exp(-value(r) * double(t));
             double drpt_dr = value(q) * double(p) * -t * std::exp(-value(r) * double(t));
-            
+
             auto tpos = tape.getPosition();
-            for (std::size_t tidx = 0; tidx < intval.size(); ++tidx)  
+            for (std::size_t tidx = 0; tidx < intval.size(); ++tidx)
             {
                 // value
                 xad::AD v = evaluate(intval[tidx], rpt);
                 // partial derivative manual
                 double dv_drpt = 2. * value(rpt) * double(intval[tidx]) + std::exp(value(rpt));
-                
+
                 // full derivatives AAD
                 tape.registerOutput(v);
                 derivative(v) = 1.0;
@@ -220,4 +219,3 @@ TEST(PartialRollback, ClearFullTape)
     EXPECT_THAT(slotq, Eq(slotq1));
     EXPECT_THAT(sloty, Eq(sloty1));
 }
-

--- a/test/ReusableRange_test.cpp
+++ b/test/ReusableRange_test.cpp
@@ -23,16 +23,14 @@
 
 ******************************************************************************/
 
-
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
-#include <vector>
 #include <algorithm>
+#include <vector>
 
 #include <XAD/ReusableRange.hpp>
 
 using namespace ::testing;
-
 
 TEST(ReusableRange, DefaultIsClosed)
 {

--- a/test/StdCompatibility_test.cpp
+++ b/test/StdCompatibility_test.cpp
@@ -1,11 +1,11 @@
-#include <XAD/StdCompatibility.hpp>
 #include <XAD/Complex.hpp>
+#include <XAD/StdCompatibility.hpp>
 #include <XAD/XAD.hpp>
 #include <cmath>
 #include <complex>
 #include <limits>
-#include <type_traits>
 #include <random>
+#include <type_traits>
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
@@ -55,7 +55,8 @@ TEST(StdCompatibility, canUseStdMath)
 
     EXPECT_THAT(std::fmod(x, x).getValue(), DoubleNear(std::fmod(xd, xd), 1e-9));
     EXPECT_THAT(std::remquo(x, x, &n).getValue(), DoubleNear(std::remquo(xd, xd, &n), 1e-9));
-    EXPECT_THAT(std::nextafter(x, 2.0*x).getValue(), DoubleNear(std::nextafter(xd, 2.0*xd), 1e-9));
+    EXPECT_THAT(std::nextafter(x, 2.0 * x).getValue(),
+                DoubleNear(std::nextafter(xd, 2.0 * xd), 1e-9));
 
     EXPECT_THAT(std::sin(x).getValue(), DoubleNear(std::sin(xd), 1e-9));
     EXPECT_THAT(std::cos(x).getValue(), DoubleNear(std::cos(xd), 1e-9));
@@ -251,7 +252,8 @@ TYPED_TEST(StdCompatibilityTempl, Traits)
                   "not implicitly convertible to char");
     static_assert(std::is_integral<TypeParam>::value == false, "not an integral type");
     static_assert(std::is_fundamental<TypeParam>::value == false, "not fundamental");
-    static_assert(!std::is_scalar<TypeParam>::value, "it's not a scalar type - would cause issues with constexpr etc");
+    static_assert(!std::is_scalar<TypeParam>::value,
+                  "it's not a scalar type - would cause issues with constexpr etc");
     static_assert(std::is_object<TypeParam>::value, "it's an object type");
     static_assert(std::is_compound<TypeParam>::value, "it's compound");
     static_assert(!std::is_trivial<TypeParam>::value, "it's not a trivial type");
@@ -263,7 +265,8 @@ TYPED_TEST(StdCompatibilityTempl, Traits)
 #if !(defined(__GNUC__) && __GNUC__ < 5) || defined(__clang__)
     static_assert(std::is_trivially_copyable<TypeParam>::value == fwd, "trivially copyable");
 #endif
-    static_assert(std::is_trivially_destructible<TypeParam>::value == fwd, "trivially destructable for fwd mode");
+    static_assert(std::is_trivially_destructible<TypeParam>::value == fwd,
+                  "trivially destructable for fwd mode");
 }
 
 template <class T>
@@ -273,7 +276,7 @@ class StdCompatibilityConstexprTempl : public ::testing::Test
 
 typedef ::testing::Types<xad::FAD, xad::FReal<xad::FReal<double>>> constexpr_test_types;
 
-#if !(_MSC_VER && _MSC_VER <= 1900)   // VS 2015 doesn't implement constexpr objects correctly
+#if !(_MSC_VER && _MSC_VER <= 1900)  // VS 2015 doesn't implement constexpr objects correctly
 
 TYPED_TEST_SUITE(StdCompatibilityConstexprTempl, constexpr_test_types);
 
@@ -302,7 +305,7 @@ TYPED_TEST(StdCompatibilityConstexprTempl, NumericLimitsConstexpr)
     XAD_UNUSED_VARIABLE(t_round);
 }
 
-#endif 
+#endif
 
 TEST(StdCompatibility, StdMinWithSizeWorks)
 {
@@ -319,7 +322,8 @@ TEST(StdCompatibility, StdMinWithSizeWorks)
     EXPECT_THAT(min_width, Ge(8));
 }
 
-TEST(StdCompatibility, UseWithRandomDistribution) {
+TEST(StdCompatibility, UseWithRandomDistribution)
+{
     std::normal_distribution<xad::AReal<double>> dst(1.0, 2.0);
 
     EXPECT_THAT(dst.mean().value(), DoubleEq(1.0));

--- a/test/Tape_test.cpp
+++ b/test/Tape_test.cpp
@@ -37,7 +37,6 @@ TEST(Tape, isEmptyByDefault)
 
     EXPECT_EQ(nullptr, Tape<double>::getActive());
 
-
     {
         Tape<double> s;
 
@@ -53,7 +52,7 @@ TEST(Tape, canInitializeDeactivated)
 {
     using xad::Tape;
     Tape<float> s(false);
-    
+
     EXPECT_FALSE(s.isActive());
     EXPECT_EQ(nullptr, Tape<float>::getActive());
 
@@ -102,7 +101,6 @@ TEST(Tape, canUnregisterInOrder)
     EXPECT_EQ(0U, s.getNumVariables());
 }
 
-
 TEST(Tape, canUnregisterOutOfOrder)
 {
     xad::Tape<double> s;
@@ -142,22 +140,26 @@ TEST(Tape, canReuseSlots)
 
     // new variables should now get slot numbers 3-5 or 8
     auto s1 = s.registerVariable();
-    EXPECT_TRUE((s1 >= 3 && s1 < 6) || s1 == 8) << "new variable not in reusable range - it is " << s1;
+    EXPECT_TRUE((s1 >= 3 && s1 < 6) || s1 == 8)
+        << "new variable not in reusable range - it is " << s1;
     EXPECT_EQ(7U, s.getNumVariables());
     EXPECT_EQ(3U, s.getNumReusableSlots());
     auto s2 = s.registerVariable();
-    EXPECT_TRUE((s2 >= 3 && s2 < 6) || s2 == 8) << "new variable not in reusable range - it is " << s1;
+    EXPECT_TRUE((s2 >= 3 && s2 < 6) || s2 == 8)
+        << "new variable not in reusable range - it is " << s1;
     EXPECT_EQ(8U, s.getNumVariables());
     EXPECT_EQ(2U, s.getNumReusableSlots());
     EXPECT_NE(s1, s2);
     auto s3 = s.registerVariable();
-    EXPECT_TRUE((s3 >= 3 && s3 < 6) || s3 == 8) << "new variable not in reusable range - it is " << s1;
+    EXPECT_TRUE((s3 >= 3 && s3 < 6) || s3 == 8)
+        << "new variable not in reusable range - it is " << s1;
     EXPECT_EQ(9U, s.getNumVariables());
     EXPECT_EQ(1U, s.getNumReusableSlots());
     EXPECT_NE(s3, s2);
     EXPECT_NE(s3, s1);
     auto s4 = s.registerVariable();
-    EXPECT_TRUE((s4 >= 3 && s4 < 6) || s4 == 8) << "new variable not in reusable range - it is " << s1;
+    EXPECT_TRUE((s4 >= 3 && s4 < 6) || s4 == 8)
+        << "new variable not in reusable range - it is " << s1;
     EXPECT_EQ(10U, s.getNumVariables());
     EXPECT_EQ(0U, s.getNumReusableSlots());
     EXPECT_NE(s4, s3);


### PR DESCRIPTION
# Description

This reformats all C++ source files according to the specs in the `.clang-format` file,
to unify the code style.